### PR TITLE
BSOA 0.5.1

### DIFF
--- a/csharp/BSOA/BSOA.Demo/BSOA.Demo.csproj
+++ b/csharp/BSOA/BSOA.Demo/BSOA.Demo.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BSOA.Json\BSOA.Json.csproj" />
+    <ProjectReference Include="..\BSOA\BSOA.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/csharp/BSOA/BSOA.Demo/FileSystemCrawler.cs
+++ b/csharp/BSOA/BSOA.Demo/FileSystemCrawler.cs
@@ -1,0 +1,49 @@
+﻿using BSOA.Demo.Model.BSOA;
+
+using System.IO;
+
+namespace BSOA.Demo
+{
+    public class FileSystemCrawler
+    {
+        public static FileSystem Crawl(string rootPath, bool simple = false)
+        {
+            FileSystem result = new FileSystem();
+            result.Folders.Add(new Folder() { Name = Path.GetFullPath(rootPath), ParentIndex = -1 });
+
+            Crawl(new DirectoryInfo(rootPath), result, 0, simple);
+
+            return result;
+        }
+
+        private static void Crawl(DirectoryInfo directory, FileSystem result, int folderIndex, bool simple = false)
+        {
+            foreach (DirectoryInfo subdirectory in directory.GetDirectories())
+            {
+                int subfolderIndex = result.Folders.Count;
+                result.Folders.Add(new Folder() { Name = subdirectory.Name, ParentIndex = folderIndex });
+
+                Crawl(subdirectory, result, subfolderIndex, simple);
+            }
+
+            foreach (FileInfo fi in directory.GetFiles())
+            {
+                Model.BSOA.File file = new Model.BSOA.File()
+                {
+                    ParentFolderIndex = folderIndex,
+                    Name = fi.Name,
+                    Length = fi.Length,
+                };
+
+                if (!simple)
+                {
+                    file.Attributes = fi.Attributes;
+                    file.CreatedUtc = fi.CreationTimeUtc;
+                    file.LastModifiedUtc = fi.LastWriteTimeUtc;
+                }
+
+                result.Files.Add(file);
+            }
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/FileSystemCrawler.cs
+++ b/csharp/BSOA/BSOA.Demo/FileSystemCrawler.cs
@@ -1,7 +1,5 @@
 ﻿using BSOA.Demo.Model.BSOA;
 
-using System.IO;
-
 namespace BSOA.Demo
 {
     public class FileSystemCrawler
@@ -9,16 +7,16 @@ namespace BSOA.Demo
         public static FileSystem Crawl(string rootPath, bool simple = false)
         {
             FileSystem result = new FileSystem();
-            result.Folders.Add(new Folder() { Name = Path.GetFullPath(rootPath), ParentIndex = -1 });
+            result.Folders.Add(new Folder() { Name = System.IO.Path.GetFullPath(rootPath), ParentIndex = -1 });
 
-            Crawl(new DirectoryInfo(rootPath), result, 0, simple);
+            Crawl(new System.IO.DirectoryInfo(rootPath), result, 0, simple);
 
             return result;
         }
 
-        private static void Crawl(DirectoryInfo directory, FileSystem result, int folderIndex, bool simple = false)
+        private static void Crawl(System.IO.DirectoryInfo directory, FileSystem result, int folderIndex, bool simple = false)
         {
-            foreach (DirectoryInfo subdirectory in directory.GetDirectories())
+            foreach (System.IO.DirectoryInfo subdirectory in directory.GetDirectories())
             {
                 int subfolderIndex = result.Folders.Count;
                 result.Folders.Add(new Folder() { Name = subdirectory.Name, ParentIndex = folderIndex });
@@ -26,9 +24,9 @@ namespace BSOA.Demo
                 Crawl(subdirectory, result, subfolderIndex, simple);
             }
 
-            foreach (FileInfo fi in directory.GetFiles())
+            foreach (System.IO.FileInfo fi in directory.GetFiles())
             {
-                Model.BSOA.File file = new Model.BSOA.File()
+                File file = new File()
                 {
                     ParentFolderIndex = folderIndex,
                     Name = fi.Name,

--- a/csharp/BSOA/BSOA.Demo/Measure.cs
+++ b/csharp/BSOA/BSOA.Demo/Measure.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace BSOA.Demo
+{
+    public static class Measure
+    {
+        private const ConsoleColor HighlightColor = ConsoleColor.Green;
+        private const double Megabyte = 1024 * 1024;
+
+        public static TimeSpan Time(string description, int iterations, Action method)
+        {
+            Console.WriteLine();
+            Console.WriteLine(description);
+            Console.Write("  ");
+
+            Stopwatch w = Stopwatch.StartNew();
+            TimeSpan elapsedAfterFirst = TimeSpan.Zero;
+
+            for (int iteration = 0; iteration < iterations; iteration++)
+            {
+                GC.Collect();
+
+                w.Restart();
+                method();
+                w.Stop();
+
+                Console.Write($"{(iteration > 0 ? " | " : "")}{w.Elapsed.TotalSeconds:n2}s");
+                if (iteration > 0) { elapsedAfterFirst += w.Elapsed; }
+            }
+
+            Console.WriteLine();
+            return (iterations == 1 ? w.Elapsed : TimeSpan.FromTicks(elapsedAfterFirst.Ticks / (iterations - 1)));
+        }
+
+        public static T LoadPerformance<T>(string path, int iterations, Func<string, T> loader)
+        {
+            T result = default(T);
+            double fileSizeMB = new FileInfo(path).Length / Megabyte;
+            double ramBeforeMB = GC.GetTotalMemory(true) / Megabyte;
+
+            string description = $"Loading {Path.GetFileName(path)} [{fileSizeMB:n1} MB] with {AssemblyDescription<T>()}...";
+
+            // Run and time the method
+            TimeSpan averageRuntime = Time(description, iterations, () => result = loader(path));
+
+            double ramAfterMB = GC.GetTotalMemory(true) / Megabyte;
+            double loadMegabytesPerSecond = fileSizeMB / averageRuntime.TotalSeconds;
+
+            ConsoleColor previous = Console.ForegroundColor;
+            Console.Write($"  -> Loaded ");
+            Console.ForegroundColor = HighlightColor;
+            Console.Write($"{fileSizeMB:n1} MB");
+            Console.ForegroundColor = previous;
+            Console.Write($" at ");
+            Console.ForegroundColor = HighlightColor;
+            Console.Write($"{loadMegabytesPerSecond:n1} MB/s");
+            Console.ForegroundColor = previous;
+            Console.Write($" into ");
+            Console.ForegroundColor = HighlightColor;
+            Console.WriteLine($"{(ramAfterMB - ramBeforeMB):n1} MB RAM");
+            Console.ForegroundColor = previous;
+
+            return result;
+        }
+
+        public static void SavePerformance(string path, int iterations, Action<string> saver)
+        {
+            string description = $"Saving as {Path.GetFileName(path)}...";
+
+            // Run and time the method
+            TimeSpan averageRuntime = Time(description, iterations, () => saver(path));
+
+            double fileSizeMB = new FileInfo(path).Length / Megabyte;
+            double saveMegabytesPerSecond = fileSizeMB / averageRuntime.TotalSeconds;
+
+            ConsoleColor previous = Console.ForegroundColor;
+            Console.Write($"  -> Saved at ");
+            Console.ForegroundColor = HighlightColor;
+            Console.Write($"{saveMegabytesPerSecond:n1} MB/s");
+            Console.ForegroundColor = previous;
+            Console.Write($" to ");
+            Console.ForegroundColor = HighlightColor;
+            Console.Write($"{fileSizeMB:n1} MB");
+            Console.ForegroundColor = previous;
+            Console.WriteLine($" file");
+        }
+
+        public static string AssemblyDescription<T>()
+        {
+            AssemblyName name = typeof(T).Assembly.GetName();
+            string suffix = typeof(T).Assembly.GetType("Microsoft.CodeAnalysis.Sarif.SarifLogDatabase") != null ? " BSOA" : "";
+            return $"{name.Name}{suffix} v{name.Version}";
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.Model;
 
 namespace BSOA.Demo.Model.BSOA

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+using BSOA.Model;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    /// <summary>
+    ///  BSOA GENERATED Entity for 'File'
+    /// </summary>
+    public partial class File : IRow, IEquatable<File>
+    {
+        private FileTable _table;
+        private int _index;
+
+        public File() : this(FileSystemDatabase.Current.File)
+        { }
+
+        public File(FileSystem root) : this(root.Database.File)
+        { }
+
+        internal File(FileTable table) : this(table, table.Count)
+        {
+            table.Add();
+        }
+        
+        internal File(FileTable table, int index)
+        {
+            this._table = table;
+            this._index = index;
+        }
+
+        public File(
+            int parentFolderIndex,
+            string name,
+            DateTime lastModifiedUtc,
+            DateTime createdUtc,
+            System.IO.FileAttributes attributes,
+            long length
+        ) 
+            : this(FileSystemDatabase.Current.File)
+        {
+            ParentFolderIndex = parentFolderIndex;
+            Name = name;
+            LastModifiedUtc = lastModifiedUtc;
+            CreatedUtc = createdUtc;
+            Attributes = attributes;
+            Length = length;
+        }
+
+        public File(File other) 
+            : this(FileSystemDatabase.Current.File)
+        {
+            ParentFolderIndex = other.ParentFolderIndex;
+            Name = other.Name;
+            LastModifiedUtc = other.LastModifiedUtc;
+            CreatedUtc = other.CreatedUtc;
+            Attributes = other.Attributes;
+            Length = other.Length;
+        }
+
+        public int ParentFolderIndex
+        {
+            get => _table.ParentFolderIndex[_index];
+            set => _table.ParentFolderIndex[_index] = value;
+        }
+
+        public string Name
+        {
+            get => _table.Name[_index];
+            set => _table.Name[_index] = value;
+        }
+
+        public DateTime LastModifiedUtc
+        {
+            get => _table.LastModifiedUtc[_index];
+            set => _table.LastModifiedUtc[_index] = value;
+        }
+
+        public DateTime CreatedUtc
+        {
+            get => _table.CreatedUtc[_index];
+            set => _table.CreatedUtc[_index] = value;
+        }
+
+        public System.IO.FileAttributes Attributes
+        {
+            get => (System.IO.FileAttributes)_table.Attributes[_index];
+            set => _table.Attributes[_index] = (int)value;
+        }
+
+        public long Length
+        {
+            get => _table.Length[_index];
+            set => _table.Length[_index] = value;
+        }
+
+        #region IEquatable<File>
+        public bool Equals(File other)
+        {
+            if (other == null) { return false; }
+
+            if (!object.Equals(this.ParentFolderIndex, other.ParentFolderIndex)) { return false; }
+            if (!object.Equals(this.Name, other.Name)) { return false; }
+            if (!object.Equals(this.LastModifiedUtc, other.LastModifiedUtc)) { return false; }
+            if (!object.Equals(this.CreatedUtc, other.CreatedUtc)) { return false; }
+            if (!object.Equals(this.Attributes, other.Attributes)) { return false; }
+            if (!object.Equals(this.Length, other.Length)) { return false; }
+
+            return true;
+        }
+        #endregion
+
+        #region Object overrides
+        public override int GetHashCode()
+        {
+            int result = 17;
+
+            unchecked
+            {
+                if (ParentFolderIndex != default(int))
+                {
+                    result = (result * 31) + ParentFolderIndex.GetHashCode();
+                }
+
+                if (Name != default(string))
+                {
+                    result = (result * 31) + Name.GetHashCode();
+                }
+
+                if (LastModifiedUtc != default(DateTime))
+                {
+                    result = (result * 31) + LastModifiedUtc.GetHashCode();
+                }
+
+                if (CreatedUtc != default(DateTime))
+                {
+                    result = (result * 31) + CreatedUtc.GetHashCode();
+                }
+
+                if (Attributes != default(System.IO.FileAttributes))
+                {
+                    result = (result * 31) + Attributes.GetHashCode();
+                }
+
+                if (Length != default(long))
+                {
+                    result = (result * 31) + Length.GetHashCode();
+                }
+            }
+
+            return result;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as File);
+        }
+
+        public static bool operator ==(File left, File right)
+        {
+            if (object.ReferenceEquals(left, null))
+            {
+                return object.ReferenceEquals(right, null);
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(File left, File right)
+        {
+            if (object.ReferenceEquals(left, null))
+            {
+                return !object.ReferenceEquals(right, null);
+            }
+
+            return !left.Equals(right);
+        }
+        #endregion
+
+        #region IRow
+        ITable IRow.Table => _table;
+        int IRow.Index => _index;
+
+        void IRow.Next()
+        {
+            _index++;
+        }
+        #endregion
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
@@ -11,10 +11,10 @@ namespace BSOA.Demo.Model.BSOA
     /// <summary>
     ///  BSOA GENERATED Entity for 'File'
     /// </summary>
-    public partial class File : IRow, IEquatable<File>
+    public partial class File : IRow<File>, IEquatable<File>
     {
-        private FileTable _table;
-        private int _index;
+        private readonly FileTable _table;
+        private readonly int _index;
 
         public File() : this(FileSystemDatabase.Current.File)
         { }
@@ -22,44 +22,21 @@ namespace BSOA.Demo.Model.BSOA
         public File(FileSystem root) : this(root.Database.File)
         { }
 
-        internal File(FileTable table) : this(table, table.Count)
+        public File(FileSystem root, File other) : this(root.Database.File, other)
+        { }
+
+        internal File(FileTable table) : this(table, table.Add()._index)
+        { }
+
+        internal File(FileTable table, File other) : this(table ?? FileSystemDatabase.Current.File)
         {
-            table.Add();
+            CopyFrom(other);
         }
-        
+
         internal File(FileTable table, int index)
         {
             this._table = table;
             this._index = index;
-        }
-
-        public File(
-            int parentFolderIndex,
-            string name,
-            DateTime lastModifiedUtc,
-            DateTime createdUtc,
-            System.IO.FileAttributes attributes,
-            long length
-        ) 
-            : this(FileSystemDatabase.Current.File)
-        {
-            ParentFolderIndex = parentFolderIndex;
-            Name = name;
-            LastModifiedUtc = lastModifiedUtc;
-            CreatedUtc = createdUtc;
-            Attributes = attributes;
-            Length = length;
-        }
-
-        public File(File other) 
-            : this(FileSystemDatabase.Current.File)
-        {
-            ParentFolderIndex = other.ParentFolderIndex;
-            Name = other.Name;
-            LastModifiedUtc = other.LastModifiedUtc;
-            CreatedUtc = other.CreatedUtc;
-            Attributes = other.Attributes;
-            Length = other.Length;
         }
 
         public int ParentFolderIndex
@@ -182,12 +159,17 @@ namespace BSOA.Demo.Model.BSOA
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<File>.Table => _table;
+        int IRow<File>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(File other)
         {
-            _index++;
+            ParentFolderIndex = other.ParentFolderIndex;
+            Name = other.Name;
+            LastModifiedUtc = other.LastModifiedUtc;
+            CreatedUtc = other.CreatedUtc;
+            Attributes = other.Attributes;
+            Length = other.Length;
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
@@ -22,15 +22,14 @@ namespace BSOA.Demo.Model.BSOA
         public File(FileSystem root) : this(root.Database.File)
         { }
 
-        public File(FileSystem root, File other) : this(root.Database.File, other)
-        { }
-
-        internal File(FileTable table) : this(table, table.Add()._index)
-        { }
-
-        internal File(FileTable table, File other) : this(table ?? FileSystemDatabase.Current.File)
+        public File(FileSystem root, File other) : this(root)
         {
             CopyFrom(other);
+        }
+
+        internal File(FileTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal File(FileTable table, int index)
@@ -38,6 +37,8 @@ namespace BSOA.Demo.Model.BSOA
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         public int ParentFolderIndex
         {

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
@@ -22,7 +22,7 @@ namespace BSOA.Demo.Model.BSOA
         public File(FileSystem root) : this(root.Database.File)
         { }
 
-        public File(FileSystem root, File other) : this(root)
+        public File(FileSystem root, File other) : this(root.Database.File)
         {
             CopyFrom(other);
         }

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
@@ -12,10 +12,10 @@ namespace BSOA.Demo.Model.BSOA
     /// <summary>
     ///  BSOA GENERATED Root Entity for 'FileSystem'
     /// </summary>
-    public partial class FileSystem : IRow
+    public partial class FileSystem : IRow<FileSystem>, IEquatable<FileSystem>
     {
-        private FileSystemTable _table;
-        private int _index;
+        private readonly FileSystemTable _table;
+        private readonly int _index;
 
         internal FileSystemDatabase Database => _table.Database;
         public ITreeSerializable DB => _table.Database;
@@ -23,9 +23,15 @@ namespace BSOA.Demo.Model.BSOA
         public FileSystem() : this(new FileSystemDatabase().FileSystem)
         { }
 
-        internal FileSystem(FileSystemTable table) : this(table, table.Count)
+        public FileSystem(FileSystem other) : this(new FileSystemDatabase().FileSystem, other)
+        { }
+
+        internal FileSystem(FileSystemTable table) : this(table, table.Add()._index)
+        { }
+
+        internal FileSystem(FileSystemTable table, FileSystem other) : this(table)
         {
-            table.Add();
+            CopyFrom(other);
         }
 
         internal FileSystem(FileSystemTable table, int index)
@@ -45,7 +51,6 @@ namespace BSOA.Demo.Model.BSOA
             get => _table.Database.File.List(_table.Files[_index]);
             set => _table.Database.File.List(_table.Files[_index]).SetTo(value);
         }
-
 
         #region IEquatable<FileSystem>
         public bool Equals(FileSystem other)
@@ -107,12 +112,13 @@ namespace BSOA.Demo.Model.BSOA
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<FileSystem>.Table => _table;
+        int IRow<FileSystem>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(FileSystem other)
         {
-            _index++;
+            Folders = other.Folders;
+            Files = other.Files;
         }
         #endregion
 

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.IO;
 using BSOA.Model;
 
@@ -43,14 +44,14 @@ namespace BSOA.Demo.Model.BSOA
 
         public IList<Folder> Folders
         {
-            get => _table.Database.Folder.List(_table.Folders[_index]);
-            set => _table.Database.Folder.List(_table.Folders[_index]).SetTo(value);
+            get => TypedList<Folder>.Get(_table.Database.Folder, _table.Folders, _index);
+            set => TypedList<Folder>.Set(_table.Database.Folder, _table.Folders, _index, value);
         }
 
         public IList<File> Files
         {
-            get => _table.Database.File.List(_table.Files[_index]);
-            set => _table.Database.File.List(_table.Files[_index]).SetTo(value);
+            get => TypedList<File>.Get(_table.Database.File, _table.Files, _index);
+            set => TypedList<File>.Set(_table.Database.File, _table.Files, _index, value);
         }
 
         #region IEquatable<FileSystem>

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 using BSOA.IO;
 using BSOA.Model;
@@ -118,7 +117,7 @@ namespace BSOA.Demo.Model.BSOA
         #endregion
 
         #region Easy Serialization
-        public void WriteBsoa(Stream stream)
+        public void WriteBsoa(System.IO.Stream stream)
         {
             using (BinaryTreeWriter writer = new BinaryTreeWriter(stream))
             {
@@ -131,7 +130,7 @@ namespace BSOA.Demo.Model.BSOA
             WriteBsoa(System.IO.File.Create(filePath));
         }
 
-        public static FileSystem ReadBsoa(Stream stream)
+        public static FileSystem ReadBsoa(System.IO.Stream stream)
         {
             using (BinaryTreeReader reader = new BinaryTreeReader(stream))
             {
@@ -151,7 +150,7 @@ namespace BSOA.Demo.Model.BSOA
             return Diagnostics(System.IO.File.OpenRead(filePath));
         }
 
-        public static TreeDiagnostics Diagnostics(Stream stream)
+        public static TreeDiagnostics Diagnostics(System.IO.Stream stream)
         {
             using (BinaryTreeReader btr = new BinaryTreeReader(stream))
             using (TreeDiagnosticsReader reader = new TreeDiagnosticsReader(btr))

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
@@ -8,46 +8,53 @@ using System.IO;
 using BSOA.IO;
 using BSOA.Model;
 
-namespace BSOA.Test.Model.V1
+namespace BSOA.Demo.Model.BSOA
 {
     /// <summary>
-    ///  BSOA GENERATED Root Entity for 'Community'
+    ///  BSOA GENERATED Root Entity for 'FileSystem'
     /// </summary>
-    public partial class Community : IRow
+    public partial class FileSystem : IRow
     {
-        private CommunityTable _table;
+        private FileSystemTable _table;
         private int _index;
 
-        internal PersonDatabase Database => _table.Database;
+        internal FileSystemDatabase Database => _table.Database;
         public ITreeSerializable DB => _table.Database;
 
-        public Community() : this(new PersonDatabase().Community)
+        public FileSystem() : this(new FileSystemDatabase().FileSystem)
         { }
 
-        internal Community(CommunityTable table) : this(table, table.Count)
+        internal FileSystem(FileSystemTable table) : this(table, table.Count)
         {
             table.Add();
         }
 
-        internal Community(CommunityTable table, int index)
+        internal FileSystem(FileSystemTable table, int index)
         {
             this._table = table;
             this._index = index;
         }
 
-        public IList<Person> People
+        public IList<Folder> Folders
         {
-            get => _table.Database.Person.List(_table.People[_index]);
-            set => _table.Database.Person.List(_table.People[_index]).SetTo(value);
+            get => _table.Database.Folder.List(_table.Folders[_index]);
+            set => _table.Database.Folder.List(_table.Folders[_index]).SetTo(value);
+        }
+
+        public IList<File> Files
+        {
+            get => _table.Database.File.List(_table.Files[_index]);
+            set => _table.Database.File.List(_table.Files[_index]).SetTo(value);
         }
 
 
-        #region IEquatable<Community>
-        public bool Equals(Community other)
+        #region IEquatable<FileSystem>
+        public bool Equals(FileSystem other)
         {
             if (other == null) { return false; }
 
-            if (!object.Equals(this.People, other.People)) { return false; }
+            if (!object.Equals(this.Folders, other.Folders)) { return false; }
+            if (!object.Equals(this.Files, other.Files)) { return false; }
 
             return true;
         }
@@ -60,9 +67,14 @@ namespace BSOA.Test.Model.V1
 
             unchecked
             {
-                if (People != default(IList<Person>))
+                if (Folders != default(IList<Folder>))
                 {
-                    result = (result * 31) + People.GetHashCode();
+                    result = (result * 31) + Folders.GetHashCode();
+                }
+
+                if (Files != default(IList<File>))
+                {
+                    result = (result * 31) + Files.GetHashCode();
                 }
             }
 
@@ -71,10 +83,10 @@ namespace BSOA.Test.Model.V1
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as Community);
+            return Equals(obj as FileSystem);
         }
 
-        public static bool operator ==(Community left, Community right)
+        public static bool operator ==(FileSystem left, FileSystem right)
         {
             if (object.ReferenceEquals(left, null))
             {
@@ -84,7 +96,7 @@ namespace BSOA.Test.Model.V1
             return left.Equals(right);
         }
 
-        public static bool operator !=(Community left, Community right)
+        public static bool operator !=(FileSystem left, FileSystem right)
         {
             if (object.ReferenceEquals(left, null))
             {
@@ -116,27 +128,27 @@ namespace BSOA.Test.Model.V1
 
         public void WriteBsoa(string filePath)
         {
-            WriteBsoa(File.Create(filePath));
+            WriteBsoa(System.IO.File.Create(filePath));
         }
 
-        public static Community ReadBsoa(Stream stream)
+        public static FileSystem ReadBsoa(Stream stream)
         {
             using (BinaryTreeReader reader = new BinaryTreeReader(stream))
             {
-                Community result = new Community();
+                FileSystem result = new FileSystem();
                 result.DB.Read(reader);
                 return result;
             }
         }
 
-        public static Community ReadBsoa(string filePath)
+        public static FileSystem ReadBsoa(string filePath)
         {
-            return ReadBsoa(File.OpenRead(filePath));
+            return ReadBsoa(System.IO.File.OpenRead(filePath));
         }
 
         public static TreeDiagnostics Diagnostics(string filePath)
         {
-            return Diagnostics(File.OpenRead(filePath));
+            return Diagnostics(System.IO.File.OpenRead(filePath));
         }
 
         public static TreeDiagnostics Diagnostics(Stream stream)
@@ -144,7 +156,7 @@ namespace BSOA.Test.Model.V1
             using (BinaryTreeReader btr = new BinaryTreeReader(stream))
             using (TreeDiagnosticsReader reader = new TreeDiagnosticsReader(btr))
             {
-                Community result = new Community();
+                FileSystem result = new FileSystem();
                 result.DB.Read(reader);
                 return reader.Tree;
             }

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
@@ -23,15 +23,14 @@ namespace BSOA.Demo.Model.BSOA
         public FileSystem() : this(new FileSystemDatabase().FileSystem)
         { }
 
-        public FileSystem(FileSystem other) : this(new FileSystemDatabase().FileSystem, other)
-        { }
-
-        internal FileSystem(FileSystemTable table) : this(table, table.Add()._index)
-        { }
-
-        internal FileSystem(FileSystemTable table, FileSystem other) : this(table)
+        public FileSystem(FileSystem other) : this(new FileSystemDatabase().FileSystem)
         {
             CopyFrom(other);
+        }
+
+        internal FileSystem(FileSystemTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal FileSystem(FileSystemTable table, int index)
@@ -39,6 +38,8 @@ namespace BSOA.Demo.Model.BSOA
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         public IList<Folder> Folders
         {

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
@@ -11,10 +11,10 @@ namespace BSOA.Demo.Model.BSOA
     /// <summary>
     ///  BSOA GENERATED Entity for 'Folder'
     /// </summary>
-    public partial class Folder : IRow, IEquatable<Folder>
+    public partial class Folder : IRow<Folder>, IEquatable<Folder>
     {
-        private FolderTable _table;
-        private int _index;
+        private readonly FolderTable _table;
+        private readonly int _index;
 
         public Folder() : this(FileSystemDatabase.Current.Folder)
         { }
@@ -22,32 +22,21 @@ namespace BSOA.Demo.Model.BSOA
         public Folder(FileSystem root) : this(root.Database.Folder)
         { }
 
-        internal Folder(FolderTable table) : this(table, table.Count)
+        public Folder(FileSystem root, Folder other) : this(root.Database.Folder, other)
+        { }
+
+        internal Folder(FolderTable table) : this(table, table.Add()._index)
+        { }
+
+        internal Folder(FolderTable table, Folder other) : this(table ?? FileSystemDatabase.Current.Folder)
         {
-            table.Add();
+            CopyFrom(other);
         }
-        
+
         internal Folder(FolderTable table, int index)
         {
             this._table = table;
             this._index = index;
-        }
-
-        public Folder(
-            int parentIndex,
-            string name
-        ) 
-            : this(FileSystemDatabase.Current.Folder)
-        {
-            ParentIndex = parentIndex;
-            Name = name;
-        }
-
-        public Folder(Folder other) 
-            : this(FileSystemDatabase.Current.Folder)
-        {
-            ParentIndex = other.ParentIndex;
-            Name = other.Name;
         }
 
         public int ParentIndex
@@ -122,12 +111,13 @@ namespace BSOA.Demo.Model.BSOA
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<Folder>.Table => _table;
+        int IRow<Folder>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(Folder other)
         {
-            _index++;
+            ParentIndex = other.ParentIndex;
+            Name = other.Name;
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.Model;
 
 namespace BSOA.Demo.Model.BSOA

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
@@ -6,54 +6,54 @@ using System.Collections.Generic;
 
 using BSOA.Model;
 
-namespace BSOA.Test.Model.V1
+namespace BSOA.Demo.Model.BSOA
 {
     /// <summary>
-    ///  BSOA GENERATED Entity for 'Person'
+    ///  BSOA GENERATED Entity for 'Folder'
     /// </summary>
-    public partial class Person : IRow, IEquatable<Person>
+    public partial class Folder : IRow, IEquatable<Folder>
     {
-        private PersonTable _table;
+        private FolderTable _table;
         private int _index;
 
-        public Person() : this(PersonDatabase.Current.Person)
+        public Folder() : this(FileSystemDatabase.Current.Folder)
         { }
 
-        public Person(Community root) : this(root.Database.Person)
+        public Folder(FileSystem root) : this(root.Database.Folder)
         { }
 
-        internal Person(PersonTable table) : this(table, table.Count)
+        internal Folder(FolderTable table) : this(table, table.Count)
         {
             table.Add();
         }
         
-        internal Person(PersonTable table, int index)
+        internal Folder(FolderTable table, int index)
         {
             this._table = table;
             this._index = index;
         }
 
-        public Person(
-            byte age,
+        public Folder(
+            int parentIndex,
             string name
         ) 
-            : this(PersonDatabase.Current.Person)
+            : this(FileSystemDatabase.Current.Folder)
         {
-            Age = age;
+            ParentIndex = parentIndex;
             Name = name;
         }
 
-        public Person(Person other) 
-            : this(PersonDatabase.Current.Person)
+        public Folder(Folder other) 
+            : this(FileSystemDatabase.Current.Folder)
         {
-            Age = other.Age;
+            ParentIndex = other.ParentIndex;
             Name = other.Name;
         }
 
-        public byte Age
+        public int ParentIndex
         {
-            get => _table.Age[_index];
-            set => _table.Age[_index] = value;
+            get => _table.ParentIndex[_index];
+            set => _table.ParentIndex[_index] = value;
         }
 
         public string Name
@@ -62,12 +62,12 @@ namespace BSOA.Test.Model.V1
             set => _table.Name[_index] = value;
         }
 
-        #region IEquatable<Person>
-        public bool Equals(Person other)
+        #region IEquatable<Folder>
+        public bool Equals(Folder other)
         {
             if (other == null) { return false; }
 
-            if (!object.Equals(this.Age, other.Age)) { return false; }
+            if (!object.Equals(this.ParentIndex, other.ParentIndex)) { return false; }
             if (!object.Equals(this.Name, other.Name)) { return false; }
 
             return true;
@@ -81,9 +81,9 @@ namespace BSOA.Test.Model.V1
 
             unchecked
             {
-                if (Age != default(byte))
+                if (ParentIndex != default(int))
                 {
-                    result = (result * 31) + Age.GetHashCode();
+                    result = (result * 31) + ParentIndex.GetHashCode();
                 }
 
                 if (Name != default(string))
@@ -97,10 +97,10 @@ namespace BSOA.Test.Model.V1
 
         public override bool Equals(object obj)
         {
-            return Equals(obj as Person);
+            return Equals(obj as Folder);
         }
 
-        public static bool operator ==(Person left, Person right)
+        public static bool operator ==(Folder left, Folder right)
         {
             if (object.ReferenceEquals(left, null))
             {
@@ -110,7 +110,7 @@ namespace BSOA.Test.Model.V1
             return left.Equals(right);
         }
 
-        public static bool operator !=(Person left, Person right)
+        public static bool operator !=(Folder left, Folder right)
         {
             if (object.ReferenceEquals(left, null))
             {

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
@@ -22,7 +22,7 @@ namespace BSOA.Demo.Model.BSOA
         public Folder(FileSystem root) : this(root.Database.Folder)
         { }
 
-        public Folder(FileSystem root, Folder other) : this(root)
+        public Folder(FileSystem root, Folder other) : this(root.Database.Folder)
         {
             CopyFrom(other);
         }

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
@@ -22,15 +22,14 @@ namespace BSOA.Demo.Model.BSOA
         public Folder(FileSystem root) : this(root.Database.Folder)
         { }
 
-        public Folder(FileSystem root, Folder other) : this(root.Database.Folder, other)
-        { }
-
-        internal Folder(FolderTable table) : this(table, table.Add()._index)
-        { }
-
-        internal Folder(FolderTable table, Folder other) : this(table ?? FileSystemDatabase.Current.Folder)
+        public Folder(FileSystem root, Folder other) : this(root)
         {
             CopyFrom(other);
+        }
+
+        internal Folder(FolderTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal Folder(FolderTable table, int index)
@@ -38,6 +37,8 @@ namespace BSOA.Demo.Model.BSOA
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         public int ParentIndex
         {

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Internal/FileSystemDatabase.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Internal/FileSystemDatabase.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+using BSOA.Model;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    /// <summary>
+    ///  BSOA GENERATED Database for 'FileSystem'
+    /// </summary>
+    internal partial class FileSystemDatabase : Database
+    {
+        internal FileTable File { get; }
+        internal FolderTable Folder { get; }
+        internal FileSystemTable FileSystem { get; }
+
+        public FileSystemDatabase()
+        {
+            _lastCreated = new WeakReference<FileSystemDatabase>(this);
+
+            File = AddTable(nameof(File), new FileTable(this));
+            Folder = AddTable(nameof(Folder), new FolderTable(this));
+            FileSystem = AddTable(nameof(FileSystem), new FileSystemTable(this));
+        }
+
+        [ThreadStatic]
+        private static WeakReference<FileSystemDatabase> _lastCreated;
+
+        internal static FileSystemDatabase Current
+        {
+            get
+            {
+                FileSystemDatabase db;
+                if (_lastCreated == null || !_lastCreated.TryGetTarget(out db)) { db = new FileSystemDatabase(); }
+                return db;
+            }
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Internal/FileSystemTable.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Internal/FileSystemTable.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+using BSOA.Column;
+using BSOA.Model;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    /// <summary>
+    ///  BSOA GENERATED Table for 'FileSystem'
+    /// </summary>
+    internal partial class FileSystemTable : Table<FileSystem>
+    {
+        internal FileSystemDatabase Database;
+
+        internal RefListColumn Folders;
+        internal RefListColumn Files;
+
+        internal FileSystemTable(FileSystemDatabase database) : base()
+        {
+            Database = database;
+
+            Folders = AddColumn(nameof(Folders), new RefListColumn(nameof(FileSystemDatabase.Folder)));
+            Files = AddColumn(nameof(Files), new RefListColumn(nameof(FileSystemDatabase.File)));
+        }
+
+        public override FileSystem Get(int index)
+        {
+            return (index == -1 ? null : new FileSystem(this, index));
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Internal/FileTable.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Internal/FileTable.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+using BSOA.Column;
+using BSOA.Model;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    /// <summary>
+    ///  BSOA GENERATED Table for 'File'
+    /// </summary>
+    internal partial class FileTable : Table<File>
+    {
+        internal FileSystemDatabase Database;
+
+        internal IColumn<int> ParentFolderIndex;
+        internal IColumn<string> Name;
+        internal IColumn<DateTime> LastModifiedUtc;
+        internal IColumn<DateTime> CreatedUtc;
+        internal IColumn<int> Attributes;
+        internal IColumn<long> Length;
+
+        internal FileTable(FileSystemDatabase database) : base()
+        {
+            Database = database;
+
+            ParentFolderIndex = AddColumn(nameof(ParentFolderIndex), database.BuildColumn<int>(nameof(File), nameof(ParentFolderIndex), default));
+            Name = AddColumn(nameof(Name), database.BuildColumn<string>(nameof(File), nameof(Name), default));
+            LastModifiedUtc = AddColumn(nameof(LastModifiedUtc), database.BuildColumn<DateTime>(nameof(File), nameof(LastModifiedUtc), default));
+            CreatedUtc = AddColumn(nameof(CreatedUtc), database.BuildColumn<DateTime>(nameof(File), nameof(CreatedUtc), default));
+            Attributes = AddColumn(nameof(Attributes), database.BuildColumn<int>(nameof(File), nameof(Attributes), (int)default));
+            Length = AddColumn(nameof(Length), database.BuildColumn<long>(nameof(File), nameof(Length), default));
+        }
+
+        public override File Get(int index)
+        {
+            return (index == -1 ? null : new File(this, index));
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Internal/FolderTable.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Internal/FolderTable.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+using BSOA.Column;
+using BSOA.Model;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    /// <summary>
+    ///  BSOA GENERATED Table for 'Folder'
+    /// </summary>
+    internal partial class FolderTable : Table<Folder>
+    {
+        internal FileSystemDatabase Database;
+
+        internal IColumn<int> ParentIndex;
+        internal IColumn<string> Name;
+
+        internal FolderTable(FileSystemDatabase database) : base()
+        {
+            Database = database;
+
+            ParentIndex = AddColumn(nameof(ParentIndex), database.BuildColumn<int>(nameof(Folder), nameof(ParentIndex), default));
+            Name = AddColumn(nameof(Name), database.BuildColumn<string>(nameof(Folder), nameof(Name), default));
+        }
+
+        public override Folder Get(int index)
+        {
+            return (index == -1 ? null : new Folder(this, index));
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFile.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFile.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+using BSOA.Json;
+using BSOA.Json.Converters;
+
+using Newtonsoft.Json;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    [JsonConverter(typeof(JsonToFile))]
+    public partial class File
+    { }
+    
+    internal class JsonToFile : JsonConverter
+    {
+        private static Dictionary<string, Action<JsonReader, FileSystem, File>> setters = new Dictionary<string, Action<JsonReader, FileSystem, File>>()
+        {
+            ["parentFolderIndex"] = (reader, root, me) => me.ParentFolderIndex = JsonToInt.Read(reader, root),
+            ["name"] = (reader, root, me) => me.Name = JsonToString.Read(reader, root),
+            ["lastModifiedUtc"] = (reader, root, me) => me.LastModifiedUtc = JsonToDateTime.Read(reader, root),
+            ["createdUtc"] = (reader, root, me) => me.CreatedUtc = JsonToDateTime.Read(reader, root),
+            ["attributes"] = (reader, root, me) => me.Attributes = JsonToEnum<System.IO.FileAttributes>.Read(reader, root),
+            ["length"] = (reader, root, me) => me.Length = JsonToLong.Read(reader, root)
+        };
+
+        public static File Read(JsonReader reader, FileSystem root = null)
+        {
+            if (reader.TokenType == JsonToken.Null) { return null; }
+            
+            File item = (root == null ? new File() : new File(root));
+            reader.ReadObject(root, item, setters);
+            return item;
+        }
+
+        public static void Write(JsonWriter writer, string propertyName, File item)
+        {
+            if (item != null)
+            {
+                writer.WritePropertyName(propertyName);
+                Write(writer, item);
+            }
+        }
+
+        public static void Write(JsonWriter writer, File item)
+        {
+            if (item == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteStartObject();
+                JsonToInt.Write(writer, "parentFolderIndex", item.ParentFolderIndex, default);
+                JsonToString.Write(writer, "name", item.Name, default);
+                JsonToDateTime.Write(writer, "lastModifiedUtc", item.LastModifiedUtc, default);
+                JsonToDateTime.Write(writer, "createdUtc", item.CreatedUtc, default);
+                JsonToEnum<System.IO.FileAttributes>.Write(writer, "attributes", item.Attributes, default);
+                JsonToLong.Write(writer, "length", item.Length, default);
+                writer.WriteEndObject();
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.Equals(typeof(File));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return Read(reader);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            Write(writer, (File)value);
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFile.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFile.cs
@@ -36,9 +36,9 @@ namespace BSOA.Demo.Model.BSOA
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, File item)
+        public static void Write(JsonWriter writer, string propertyName, File item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFileSystem.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+using BSOA.Json;
+using BSOA.Json.Converters;
+
+using Newtonsoft.Json;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    [JsonConverter(typeof(JsonToFileSystem))]
+    public partial class FileSystem
+    { }
+
+    internal class JsonToFileSystem : JsonConverter
+    {
+        private static Dictionary<string, Action<JsonReader, FileSystem, FileSystem>> setters = new Dictionary<string, Action<JsonReader, FileSystem, FileSystem>>()
+        {
+            ["folders"] = (reader, root, me) => JsonToIList<Folder>.Read(reader, root, me.Folders, JsonToFolder.Read),
+            ["files"] = (reader, root, me) => JsonToIList<File>.Read(reader, root, me.Files, JsonToFile.Read)
+        };
+
+        public static FileSystem Read(JsonReader reader, FileSystem root = null)
+        {
+            if (reader.TokenType == JsonToken.Null) { return null; }
+
+            FileSystem item = new FileSystem();
+
+            // FileSystem is root object
+            root = item;
+
+            reader.ReadObject(root, item, setters);
+
+            // Trim after read to consolidate 'during read' content
+            item.DB.Trim();
+
+            return item;
+        }
+
+        public static void Write(JsonWriter writer, string propertyName, FileSystem item)
+        {
+            if (item != null)
+            {
+                writer.WritePropertyName(propertyName);
+                Write(writer, item);
+            }
+        }
+
+        public static void Write(JsonWriter writer, FileSystem item)
+        {
+            if (item == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteStartObject();
+                JsonToIList<Folder>.Write(writer, "folders", item.Folders, JsonToFolder.Write);
+                JsonToIList<File>.Write(writer, "files", item.Files, JsonToFile.Write);
+                writer.WriteEndObject();
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.Equals(typeof(FileSystem));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return Read(reader);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            Write(writer, (FileSystem)value);
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFileSystem.cs
@@ -19,8 +19,8 @@ namespace BSOA.Demo.Model.BSOA
     {
         private static Dictionary<string, Action<JsonReader, FileSystem, FileSystem>> setters = new Dictionary<string, Action<JsonReader, FileSystem, FileSystem>>()
         {
-            ["folders"] = (reader, root, me) => JsonToIList<Folder>.Read(reader, root, me.Folders, JsonToFolder.Read),
-            ["files"] = (reader, root, me) => JsonToIList<File>.Read(reader, root, me.Files, JsonToFile.Read)
+            ["folders"] = (reader, root, me) => me.Folders = JsonToIList<Folder>.Read(reader, root, null, JsonToFolder.Read),
+            ["files"] = (reader, root, me) => me.Files = JsonToIList<File>.Read(reader, root, null, JsonToFile.Read)
         };
 
         public static FileSystem Read(JsonReader reader, FileSystem root = null)

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFileSystem.cs
@@ -40,9 +40,9 @@ namespace BSOA.Demo.Model.BSOA
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, FileSystem item)
+        public static void Write(JsonWriter writer, string propertyName, FileSystem item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFolder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFolder.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+using BSOA.Json;
+using BSOA.Json.Converters;
+
+using Newtonsoft.Json;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    [JsonConverter(typeof(JsonToFolder))]
+    public partial class Folder
+    { }
+    
+    internal class JsonToFolder : JsonConverter
+    {
+        private static Dictionary<string, Action<JsonReader, FileSystem, Folder>> setters = new Dictionary<string, Action<JsonReader, FileSystem, Folder>>()
+        {
+            ["parentIndex"] = (reader, root, me) => me.ParentIndex = JsonToInt.Read(reader, root),
+            ["name"] = (reader, root, me) => me.Name = JsonToString.Read(reader, root)
+        };
+
+        public static Folder Read(JsonReader reader, FileSystem root = null)
+        {
+            if (reader.TokenType == JsonToken.Null) { return null; }
+            
+            Folder item = (root == null ? new Folder() : new Folder(root));
+            reader.ReadObject(root, item, setters);
+            return item;
+        }
+
+        public static void Write(JsonWriter writer, string propertyName, Folder item)
+        {
+            if (item != null)
+            {
+                writer.WritePropertyName(propertyName);
+                Write(writer, item);
+            }
+        }
+
+        public static void Write(JsonWriter writer, Folder item)
+        {
+            if (item == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteStartObject();
+                JsonToInt.Write(writer, "parentIndex", item.ParentIndex, default);
+                JsonToString.Write(writer, "name", item.Name, default);
+                writer.WriteEndObject();
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.Equals(typeof(Folder));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return Read(reader);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            Write(writer, (Folder)value);
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFolder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Json/JsonToFolder.cs
@@ -32,9 +32,9 @@ namespace BSOA.Demo.Model.BSOA
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, Folder item)
+        public static void Write(JsonWriter writer, string propertyName, Folder item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA_Ext/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA_Ext/File.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using BSOA.Model;
+
+using System;
 
 namespace BSOA.Demo.Model.BSOA
 {

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA_Ext/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA_Ext/File.cs
@@ -1,0 +1,12 @@
+﻿using System.IO;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    public partial class File
+    {
+        public string Description(FileSystem db)
+        {
+            return $"{db.Folders[ParentFolderIndex].FullPath(db)}\\{Name} | {Length:n0} | {LastModifiedUtc:u}";
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA_Ext/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA_Ext/FileSystem.cs
@@ -1,0 +1,58 @@
+﻿using BSOA.Json;
+using BSOA.Model;
+
+using System;
+using System.IO;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    public partial class FileSystem
+    {
+        public int FileNamesContaining(Memory<byte> value)
+        {
+            int matchCount = 0;
+
+            ((INumberColumn<byte>)this.Database.File.Name).ForEach((slice) =>
+            {
+                Span<byte> sliceSpan = slice.Array.AsSpan().Slice(slice.Index, slice.Count);
+
+                while (sliceSpan.Length > 0)
+                {
+                    int nextMatch = sliceSpan.IndexOf(value.Span);
+                    if (nextMatch == -1) { break; }
+                    matchCount++;
+                    sliceSpan = sliceSpan.Slice(nextMatch + value.Length);
+                }
+            });
+            return matchCount;
+        }
+
+        public void Save(string filePath)
+        {
+            string extension = Path.GetExtension(filePath).ToLowerInvariant();
+            switch (extension)
+            {
+                case ".bsoa":
+                    WriteBsoa(filePath);
+                    break;
+
+                default:
+                    AsJson.Save(filePath, this);
+                    break;
+            }
+        }
+
+        public static FileSystem Load(string filePath)
+        {
+            string extension = Path.GetExtension(filePath).ToLowerInvariant();
+            switch (extension)
+            {
+                case ".bsoa":
+                    return ReadBsoa(filePath);
+
+                default:
+                    return AsJson.Load<FileSystem>(filePath);
+            }
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA_Ext/Folder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA_Ext/Folder.cs
@@ -1,0 +1,25 @@
+﻿using System.Text;
+
+namespace BSOA.Demo.Model.BSOA
+{
+    public partial class Folder
+    {
+        public string FullPath(FileSystem fileSystem)
+        {
+            StringBuilder path = new StringBuilder();
+            FullPath(fileSystem, path);
+            return path.ToString();
+        }
+
+        private void FullPath(FileSystem fileSystem, StringBuilder path)
+        {
+            if (ParentIndex != -1)
+            {
+                fileSystem.Folders[ParentIndex].FullPath(fileSystem, path);
+                path.Append("\\");
+            }
+
+            path.Append(Name);
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/Classic/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/Classic/File.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+
+namespace BSOA.Demo.Model.Classic
+{
+    public class File
+    {
+        public int ParentFolderIndex { get; set; }
+
+        public string Name { get; set; }
+        public DateTime LastModifiedUtc { get; set; }
+        public DateTime CreatedUtc { get; set; }
+        public FileAttributes Attributes { get; set; }
+        public long Length { get; set; }
+
+        public File()
+        { }
+
+        public string Description(FileSystem db)
+        {
+            return $"{db.Folders[ParentFolderIndex].FullPath(db)}\\{Name} | {Length:n0} | {LastModifiedUtc:u}";
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/Classic/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/Classic/FileSystem.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace BSOA.Demo.Model.Classic
+{
+    public class FileSystem
+    {
+        public IList<Folder> Folders { get; set; }
+        public IList<File> Files { get; set; }
+
+        public FileSystem()
+        {
+            Folders = new List<Folder>();
+            Files = new List<File>();
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Model/Classic/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/Classic/FileSystem.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using BSOA.Json;
+
+using System.Collections.Generic;
 
 namespace BSOA.Demo.Model.Classic
 {
@@ -11,6 +13,16 @@ namespace BSOA.Demo.Model.Classic
         {
             Folders = new List<Folder>();
             Files = new List<File>();
+        }
+
+        public void Save(string filePath)
+        {
+            AsJson.Save(filePath, this);
+        }
+
+        public static FileSystem Load(string filePath)
+        {
+            return AsJson.Load<FileSystem>(filePath);
         }
     }
 }

--- a/csharp/BSOA/BSOA.Demo/Model/Classic/Folder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/Classic/Folder.cs
@@ -1,0 +1,28 @@
+﻿using System.Text;
+
+namespace BSOA.Demo.Model.Classic
+{
+    public class Folder
+    {
+        public int ParentIndex { get; set; }
+        public string Name { get; set; }
+
+        public string FullPath(FileSystem fileSystem)
+        {
+            StringBuilder path = new StringBuilder();
+            FullPath(fileSystem, path);
+            return path.ToString();
+        }
+
+        private void FullPath(FileSystem fileSystem, StringBuilder path)
+        {
+            if (ParentIndex != -1)
+            {
+                fileSystem.Folders[ParentIndex].FullPath(fileSystem, path);
+                path.Append("\\");
+            }
+
+            path.Append(Name);
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Demo/Program.cs
+++ b/csharp/BSOA/BSOA.Demo/Program.cs
@@ -1,0 +1,105 @@
+﻿using BSOA.Demo.Model.BSOA;
+using BSOA.Json;
+
+using System;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace BSOA.Demo
+{
+    class Program
+    {
+        public const string Usage = @"BSOA.Demo <mode> <dbPath> <args>
+  BSOA.Demo crawl  <DBPath> <RootPathToCrawl>
+  BSOA.Demo load   <DBPath>
+  BSOA.Demo search <DBPath> <FileNamePart>";
+
+        static int Main(string[] args)
+        {
+            try
+            {
+                if (args.Length < 2) { throw new UsageException("Not enough arguments."); }
+                string mode = args[0].ToLowerInvariant();
+                string databasePath = args[1];
+
+                FileSystem db = null;
+
+                switch (mode)
+                {
+                    case "crawl":
+                        if (args.Length < 3) { throw new UsageException("'crawl' requires DBPath and PathToCrawl."); }
+
+                        Measure.Time("Crawl", 1, () =>
+                        {
+                            db = FileSystemCrawler.Crawl(rootPath: args[2], simple: (args.Length > 3 ? bool.Parse(args[3]) : false));
+                        });
+
+                        Measure.Time("Save (JSON)", 1, () =>
+                        {
+                            AsJson.Save(databasePath, db);
+                        });
+
+                        db.WriteBsoa(System.IO.Path.ChangeExtension(databasePath, ".bsoa"));
+
+                        break;
+
+                    case "load":
+                        db = Measure.LoadPerformance(databasePath, 5, AsJson.Load<FileSystem>);
+                        break;
+
+                    case "search":
+                        if (args.Length < 3) { throw new UsageException("'search' requires DBPath and FileNamePart."); }
+                        string searchString = args[2];
+
+                        //db = Measure.LoadPerformance(databasePath, 1, AsJson.Load<FileSystem>);
+                        db = Measure.LoadPerformance(databasePath, 1, (path) => FileSystem.ReadBsoa(System.IO.Path.ChangeExtension(path, ".bsoa")));
+
+                        Measure.Time("Search", 1, () =>
+                        {
+                            int matchCount = 0;
+
+                            foreach (var file in db.Files.Where((f) => f.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase)))
+                            {
+                                matchCount++;
+                                if (matchCount < 15)
+                                {
+                                    Console.WriteLine($" -> {file.Description(db)}");
+                                }
+                            }
+
+                            Console.WriteLine($"{matchCount:n0} matches found.");
+                        });
+
+                        break;
+
+                    default:
+                        Console.WriteLine($"Unknown mode '{mode}'");
+                        Console.WriteLine(Usage);
+                        return -2;
+                }
+
+                return 0;
+            }
+            catch (UsageException ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(Usage);
+                return -2;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ERROR: {ex}");
+                return -1;
+            }
+        }
+    }
+
+    [Serializable]
+    public class UsageException : Exception
+    {
+        public UsageException() { }
+        public UsageException(string message) : base(message) { }
+        public UsageException(string message, Exception inner) : base(message, inner) { }
+        protected UsageException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/csharp/BSOA/BSOA.Generator/ClassGenerator.cs
+++ b/csharp/BSOA/BSOA.Generator/ClassGenerator.cs
@@ -16,11 +16,11 @@ namespace BSOA.Generator
         public TemplateType Type { get; set; }
         public string Code { get; set; }
         public Dictionary<string, string> Templates { get; set; }
-        public Dictionary<string, string> PostReplacements { get; set; }
+        public PostReplacements PostReplacements { get; set; }
 
         public string OutputPathFormatString { get; set; }
 
-        public ClassGenerator(TemplateType type, string templateFilePath, string outputPathFormatString, Dictionary<string, string> postReplacements = null)
+        public ClassGenerator(TemplateType type, string templateFilePath, string outputPathFormatString, PostReplacements postReplacements = null)
         {
             Type = type;
             Code = File.ReadAllText(templateFilePath);
@@ -100,11 +100,12 @@ namespace BSOA.Generator
                 finalCode = finalCode.Replace(TemplateDefaults.TableName, table.Name);
             }
 
+            string filePath = Path.Combine(outputFolder, string.Format(OutputPathFormatString, table?.Name ?? database.Name));
+
             // Make any post-replacements
-            finalCode = CodeSection.MakeReplacements(finalCode, PostReplacements);
+            finalCode = PostReplacements.Apply(filePath, finalCode);
 
             // Write to desired output folder
-            string filePath = Path.Combine(outputFolder, string.Format(OutputPathFormatString, table?.Name ?? database.Name));
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
             File.WriteAllText(filePath, finalCode);
         }

--- a/csharp/BSOA/BSOA.Generator/CodeSection.cs
+++ b/csharp/BSOA/BSOA.Generator/CodeSection.cs
@@ -141,18 +141,5 @@ namespace BSOA.Generator
 
             return populated;
         }
-
-        public static string MakeReplacements(string code, Dictionary<string, string> replacements)
-        {
-            if (replacements?.Count > 0)
-            {
-                foreach (KeyValuePair<string, string> replacement in replacements)
-                {
-                    code = Regex.Replace(code, replacement.Key, replacement.Value, Options);
-                }
-            }
-
-            return code;
-        }
     }
 }

--- a/csharp/BSOA/BSOA.Generator/FullGenerator.cs
+++ b/csharp/BSOA/BSOA.Generator/FullGenerator.cs
@@ -75,7 +75,7 @@ namespace BSOA.Generator
         {
             postReplacements.Replacements.Add(new PostReplacement(
                 replace: "me.([^ ]+) = JsonToIList<([^>]+)>.Read\\(reader, root\\)",
-                with: "JsonToIList<$2>.Read(reader, root, me.$1, JsonTo$2.Read)"
+                with: "me.$1 = JsonToIList<$2>.Read(reader, root, null, JsonTo$2.Read)"
             ));
 
             postReplacements.Replacements.Add(new PostReplacement(

--- a/csharp/BSOA/BSOA.Generator/PostReplacements.cs
+++ b/csharp/BSOA/BSOA.Generator/PostReplacements.cs
@@ -1,0 +1,86 @@
+﻿using Newtonsoft.Json;
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace BSOA.Generator
+{
+    public class PostReplacement
+    {
+        [JsonIgnore]
+        public const RegexOptions Options = RegexOptions.Singleline | RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
+
+        /// <summary>
+        ///  Regex or String to be replaced
+        /// </summary>
+        public string Replace { get; set; }
+
+        /// <summary>
+        ///  Regex or String to insert as replacement; use $n to refer to groups.
+        /// </summary>
+        public string With { get; set; }
+
+        /// <summary>
+        ///  Regex identifying files to replace; null or empty will apply to all files
+        /// </summary>
+        public string Files { get; set; }
+
+        /// <summary>
+        ///  Optional description to explain the Replacement purpose
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        ///  Whether the Replace and With values are plain text rather than Regexes
+        /// </summary>
+        public bool ArePlainText { get; set; }
+
+        public PostReplacement(string replace, string with, string files = null, bool arePlainText = false)
+        {
+            Replace = replace;
+            With = with;
+            Files = files;
+            ArePlainText = arePlainText;
+        }
+
+        public string Apply(string targetFilePath, string code)
+        {
+            if (String.IsNullOrEmpty(Files) || Regex.IsMatch(targetFilePath, Files, Options))
+            {
+                if (ArePlainText)
+                {
+                    code = code.Replace(Replace, With, StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    code = Regex.Replace(code, Replace, With, Options);
+                }
+            }
+
+            return code;
+        }
+    }
+
+    public class PostReplacements
+    {
+        public RegexOptions Options { get; set; }
+        public List<PostReplacement> Replacements { get; set; }
+
+        public PostReplacements()
+        {
+            Options = RegexOptions.Singleline | RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
+            Replacements = new List<PostReplacement>();
+        }
+
+        public string Apply(string targetFilePath, string code)
+        {
+            foreach (PostReplacement r in Replacements)
+            {
+                code = r.Apply(targetFilePath, code);
+            }
+
+            return code;
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Generator/Regenerate.cmd
+++ b/csharp/BSOA/BSOA.Generator/Regenerate.cmd
@@ -7,4 +7,7 @@ ECHO Generating Unit Test models...
 %BSOAGenerator% "Schemas\Person.UnitTest.V1.schema.json" "..\BSOA.Test\Model\V1"
 %BSOAGenerator% "Schemas\Person.UnitTest.V2.schema.json" "..\BSOA.Test\Model\V2"
 
+ECHO Generating Demo model...
+%BSOAGenerator% "Schemas\FileSystem.schema.json" "..\BSOA.Demo\Model\BSOA"
+
 POPD

--- a/csharp/BSOA/BSOA.Generator/Schemas/FileSystem.schema.json
+++ b/csharp/BSOA/BSOA.Generator/Schemas/FileSystem.schema.json
@@ -1,0 +1,68 @@
+{
+  "name": "FileSystemDatabase",
+  "namespace": "BSOA.Demo.Model.BSOA",
+  "rootTableName": "FileSystem",
+  "tables": [
+    {
+      "name": "File",
+      "columns": [
+        {
+          "name": "ParentFolderIndex",
+          "type": "int"
+        },
+        {
+          "name": "Name",
+          "type": "string"
+        },
+        {
+          "name": "LastModifiedUtc",
+          "type": "DateTime"
+        },
+        {
+          "name": "CreatedUtc",
+          "type": "DateTime"
+        },
+        {
+          "name": "Attributes",
+          "type": "System.IO.FileAttributes",
+          "category": "Enum",
+          "underlyingType": "int"
+        },
+        {
+          "name": "Length",
+          "type": "long"
+        }
+      ]
+    },
+    {
+      "name": "Folder",
+      "columns": [
+        {
+          "name": "ParentIndex",
+          "type": "int"
+        },
+        {
+          "name": "Name",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "FileSystem",
+      "columns": [
+        {
+          "name": "Folders",
+          "type": "IList<Folder>",
+          "category": "RefList",
+          "referencedTableName": "Folder"
+        },
+        {
+          "name": "Files",
+          "type": "IList<File>",
+          "category": "RefList",
+          "referencedTableName": "File"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/BSOA/BSOA.Generator/Schemas/Sample.PostReplacements.json
+++ b/csharp/BSOA/BSOA.Generator/Schemas/Sample.PostReplacements.json
@@ -1,0 +1,20 @@
+{
+  "replacements": [
+    {
+      "replace": "me.([^ ]+) = JsonToIList<([^>]+)>.Read\\(reader, root\\)",
+      "with": "JsonToIList<$2>.Read(reader, root, me.$1, JsonTo$2.Read)"
+    },
+    {
+      "replace": "JsonToIList<([^>]+)>.Write\\(writer, ([^,]+), item.([^,]+), default\\);",
+      "with": "JsonToIList<$1>.Write(writer, $2, item.$3, JsonTo$1.Write);"
+    },
+    {
+      "replace": "me.([^ ]+) = JsonToIDictionary<String, ([^>]+)>.Read\\(reader, root\\)",
+      "with": "me.$1 = JsonToIDictionary<String, $2>.Read(reader, root, null, JsonTo$2.Read)"
+    },
+    {
+      "replace": "JsonToIDictionary<String, ([^>]+)>.Write\\(writer, ([^,]+), item.([^,]+), default\\);",
+      "with": "JsonToIDictionary<String, $1>.Write(writer, $2, item.$3, JsonTo$1.Write);"
+    }
+  ]
+}

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.IO;
 using BSOA.Model;
 
@@ -69,8 +70,8 @@ namespace BSOA.Generator.Templates
         //  <RefListColumn>
         public IList<Employee> Members
         {
-            get => _table.Database.Employee.List(_table.Members[_index]);
-            set => _table.Database.Employee.List(_table.Members[_index]).SetTo(value);
+            get => TypedList<Employee>.Get(_table.Database.Employee, _table.Members, _index);
+            set => TypedList<Employee>.Set(_table.Database.Employee, _table.Members, _index, value);
         }
 
         //  </RefListColumn>

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -61,7 +61,7 @@ namespace BSOA.Generator.Templates
         //  <RefColumn>
         public Employee Owner
         {
-            get => _table.Database.Employee[_table.Owner[_index]];
+            get => _table.Database.Employee.Get(_table.Owner[_index]);
             set => _table.Owner[_index] = _table.LocalIndex(value);
         }
 
@@ -74,11 +74,6 @@ namespace BSOA.Generator.Templates
         }
 
         //  </RefListColumn>
-        public IList<Team> Teams
-        {
-            get => _table.Database.Team.List(_table.Teams[_index]);
-            set => _table.Database.Team.List(_table.Teams[_index]).SetTo(value);
-        }
         // </ColumnList>
 
         #region IEquatable<Company>

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -62,7 +62,9 @@ namespace BSOA.Generator.Templates
         public Employee Owner
         {
             get => _table.Database.Employee[_table.Owner[_index]];
+            set => _table.Owner[_index] = _table.LocalIndex(value);
         }
+
         //  </RefColumn>
         //  <RefListColumn>
         public IList<Employee> Members

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 using BSOA.IO;
 using BSOA.Model;
@@ -164,7 +163,7 @@ namespace BSOA.Generator.Templates
         #endregion
 
         #region Easy Serialization
-        public void WriteBsoa(Stream stream)
+        public void WriteBsoa(System.IO.Stream stream)
         {
             using (BinaryTreeWriter writer = new BinaryTreeWriter(stream))
             {
@@ -174,10 +173,10 @@ namespace BSOA.Generator.Templates
 
         public void WriteBsoa(string filePath)
         {
-            WriteBsoa(File.Create(filePath));
+            WriteBsoa(System.IO.File.Create(filePath));
         }
 
-        public static Company ReadBsoa(Stream stream)
+        public static Company ReadBsoa(System.IO.Stream stream)
         {
             using (BinaryTreeReader reader = new BinaryTreeReader(stream))
             {
@@ -189,15 +188,15 @@ namespace BSOA.Generator.Templates
 
         public static Company ReadBsoa(string filePath)
         {
-            return ReadBsoa(File.OpenRead(filePath));
+            return ReadBsoa(System.IO.File.OpenRead(filePath));
         }
 
         public static TreeDiagnostics Diagnostics(string filePath)
         {
-            return Diagnostics(File.OpenRead(filePath));
+            return Diagnostics(System.IO.File.OpenRead(filePath));
         }
 
-        public static TreeDiagnostics Diagnostics(Stream stream)
+        public static TreeDiagnostics Diagnostics(System.IO.Stream stream)
         {
             using (BinaryTreeReader btr = new BinaryTreeReader(stream))
             using (TreeDiagnosticsReader reader = new TreeDiagnosticsReader(btr))

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -81,11 +81,11 @@ namespace BSOA.Generator.Templates
 
             // <EqualsList>
             //  <Equals>
-            if (this.Id != other.Id) { return false; }
+            if (!object.Equals(this.Id, other.Id)) { return false; }
             //  </Equals>
-            if (this.JoinPolicy != other.JoinPolicy) { return false; }
-            if (this.Owner != other.Owner) { return false; }
-            if (this.Members != other.Members) { return false; }
+            if (!object.Equals(this.JoinPolicy, other.JoinPolicy)) { return false; }
+            if (!object.Equals(this.Owner, other.Owner)) { return false; }
+            if (!object.Equals(this.Members, other.Members)) { return false; }
             // </EqualsList>
 
             return true;

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -62,7 +62,7 @@ namespace BSOA.Generator.Templates
         public Employee Owner
         {
             get => _table.Database.Employee.Get(_table.Owner[_index]);
-            set => _table.Owner[_index] = _table.LocalIndex(value);
+            set => _table.Owner[_index] = _table.Database.Employee.LocalIndex(value);
         }
 
         //  </RefColumn>

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -23,15 +23,14 @@ namespace BSOA.Generator.Templates
         public Company() : this(new CompanyDatabase().Company)
         { }
 
-        public Company(Company other) : this(new CompanyDatabase().Company, other)
-        { }
-
-        internal Company(CompanyTable table) : this(table, table.Add()._index)
-        { }
-
-        internal Company(CompanyTable table, Company other) : this(table)
+        public Company(Company other) : this(new CompanyDatabase().Company)
         {
             CopyFrom(other);
+        }
+
+        internal Company(CompanyTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal Company(CompanyTable table, int index)
@@ -39,6 +38,8 @@ namespace BSOA.Generator.Templates
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         // <ColumnList>
         //   <SimpleColumn>

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -12,10 +12,10 @@ namespace BSOA.Generator.Templates
     /// <summary>
     ///  BSOA GENERATED Root Entity for 'Company'
     /// </summary>
-    public partial class Company : IRow
+    public partial class Company : IRow<Company>, IEquatable<Company>
     {
-        private CompanyTable _table;
-        private int _index;
+        private readonly CompanyTable _table;
+        private readonly int _index;
 
         internal CompanyDatabase Database => _table.Database;
         public ITreeSerializable DB => _table.Database;
@@ -23,9 +23,15 @@ namespace BSOA.Generator.Templates
         public Company() : this(new CompanyDatabase().Company)
         { }
 
-        internal Company(CompanyTable table) : this(table, table.Count)
+        public Company(Company other) : this(new CompanyDatabase().Company, other)
+        { }
+
+        internal Company(CompanyTable table) : this(table, table.Add()._index)
+        { }
+
+        internal Company(CompanyTable table, Company other) : this(table)
         {
-            table.Add();
+            CopyFrom(other);
         }
 
         internal Company(CompanyTable table, int index)
@@ -71,7 +77,6 @@ namespace BSOA.Generator.Templates
             set => _table.Database.Team.List(_table.Teams[_index]).SetTo(value);
         }
         // </ColumnList>
-
 
         #region IEquatable<Company>
         public bool Equals(Company other)
@@ -153,12 +158,19 @@ namespace BSOA.Generator.Templates
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<Company>.Table => _table;
+        int IRow<Company>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(Company other)
         {
-            _index++;
+            // <OtherAssignmentList>
+            //  <OtherAssignment>
+            Id = other.Id;
+            //  </OtherAssignment>
+            JoinPolicy = other.JoinPolicy;
+            Owner = other.Owner;
+            Members = other.Members;
+            // </OtherAssignmentList>
         }
         #endregion
 

--- a/csharp/BSOA/BSOA.Generator/Templates/Employee.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Employee.cs
@@ -23,15 +23,14 @@ namespace BSOA.Generator.Templates
         public Employee(Company root) : this(root.Database.Employee)
         { }
 
-        public Employee(Company root, Employee other) : this(root.Database.Employee, other)
-        { }
-
-        internal Employee(EmployeeTable table) : this(table, table.Add()._index)
-        { }
-
-        internal Employee(EmployeeTable table, Employee other) : this(table ?? CompanyDatabase.Current.Employee)
+        public Employee(Company root, Employee other) : this(root)
         {
             CopyFrom(other);
+        }
+
+        internal Employee(EmployeeTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal Employee(EmployeeTable table, int index)
@@ -39,6 +38,8 @@ namespace BSOA.Generator.Templates
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         public string Name
         {

--- a/csharp/BSOA/BSOA.Generator/Templates/Employee.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Employee.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Reflection;
 
 using BSOA.Model;
 
@@ -13,8 +14,8 @@ namespace BSOA.Generator.Templates
     /// </summary>
     public partial class Employee : IRow
     {
-        private EmployeeTable _table;
-        private int _index;
+        private readonly EmployeeTable _table;
+        private readonly int _index;
 
         public Employee() : this(CompanyDatabase.Current.Employee)
         { }
@@ -22,9 +23,15 @@ namespace BSOA.Generator.Templates
         public Employee(Company root) : this(root.Database.Employee)
         { }
 
-        internal Employee(EmployeeTable table) : this(table, table.Count)
+        public Employee(Company root, Employee other) : this(root.Database.Employee, other)
+        { }
+
+        internal Employee(EmployeeTable table) : this(table, table.Add()._index)
+        { }
+
+        internal Employee(EmployeeTable table, Employee other) : this(table ?? CompanyDatabase.Current.Employee)
         {
-            table.Add();
+            CopyFrom(other);
         }
 
         internal Employee(EmployeeTable table, int index)
@@ -40,15 +47,13 @@ namespace BSOA.Generator.Templates
         }
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<Employee>.Table => _table;
+        int IRow<Employee>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(Employee other)
         {
-            _index++;
+            Name = other.Name;
         }
-
-        internal CompanyDatabase Database => _table.Database;
         #endregion
     }
 }

--- a/csharp/BSOA/BSOA.Generator/Templates/Json/JsonToCompany.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Json/JsonToCompany.cs
@@ -30,7 +30,7 @@ namespace BSOA.Generator.Templates
             ["owner"] = (reader, root, me) => me.Owner = JsonToEmployee.Read(reader, root),
             //   </RefSetter>
             //   <RefListSetter>
-            ["members"] = (reader, root, me) => JsonToIList<Employee>.Read(reader, root, me.Members, JsonToEmployee.Read),
+            ["members"] = (reader, root, me) => me.Members = JsonToIList<Employee>.Read(reader, root, null, JsonToEmployee.Read),
             //   </RefListSetter>
             // </SetterList>
         };

--- a/csharp/BSOA/BSOA.Generator/Templates/Json/JsonToCompany.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Json/JsonToCompany.cs
@@ -52,9 +52,9 @@ namespace BSOA.Generator.Templates
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, Company item)
+        public static void Write(JsonWriter writer, string propertyName, Company item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Generator/Templates/Json/JsonToTeam.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Json/JsonToTeam.cs
@@ -30,7 +30,7 @@ namespace BSOA.Generator.Templates
             ["owner"] = (reader, root, me) => me.Owner = JsonToEmployee.Read(reader, root),
             //   </RefSetter>
             //   <RefListSetter>
-            ["members"] = (reader, root, me) => JsonToIList<Employee>.Read(reader, root, me.Members, JsonToEmployee.Read),
+            ["members"] = (reader, root, me) => me.Members = JsonToIList<Employee>.Read(reader, root, null, JsonToEmployee.Read),
             //   </RefListSetter>
             // </SetterList>
         };

--- a/csharp/BSOA/BSOA.Generator/Templates/Json/JsonToTeam.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Json/JsonToTeam.cs
@@ -44,9 +44,9 @@ namespace BSOA.Generator.Templates
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, Team item)
+        public static void Write(JsonWriter writer, string propertyName, Team item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Generator/Templates/Team.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Team.cs
@@ -11,10 +11,10 @@ namespace BSOA.Generator.Templates
     /// <summary>
     ///  BSOA GENERATED Entity for 'Team'
     /// </summary>
-    public partial class Team : IRow, IEquatable<Team>
+    public partial class Team : IRow<Team>, IEquatable<Team>
     {
-        private TeamTable _table;
-        private int _index;
+        private readonly TeamTable _table;
+        private readonly int _index;
 
         public Team() : this(CompanyDatabase.Current.Team)
         { }
@@ -22,50 +22,21 @@ namespace BSOA.Generator.Templates
         public Team(Company root) : this(root.Database.Team)
         { }
 
-        internal Team(TeamTable table) : this(table, table.Count)
+        public Team(Company root, Team other) : this(root.Database.Team, other)
+        { }
+
+        internal Team(TeamTable table) : this(table, table.Add()._index)
+        { }
+
+        internal Team(TeamTable table, Team other) : this(table ?? CompanyDatabase.Current.Team)
         {
-            table.Add();
+            CopyFrom(other);
         }
-        
+
         internal Team(TeamTable table, int index)
         {
             this._table = table;
             this._index = index;
-        }
-
-        public Team(
-            // <ArgumentList>
-            //  <Argument>
-            long id,
-            //  </Argument>
-            SecurityPolicy joinPolicy,
-            Employee owner,
-            IList<Employee> members
-            // </ArgumentList>
-        ) 
-            : this(CompanyDatabase.Current.Team)
-        {
-            // <AssignmentList>
-            //  <Assignment>
-            Id = id;
-            //  </Assignment>
-            JoinPolicy = joinPolicy;
-            Owner = owner;
-            Members = members;
-            // </AssignmentList>
-        }
-
-        public Team(Team other) 
-            : this(CompanyDatabase.Current.Team)
-        {
-            // <OtherAssignmentList>
-            //  <OtherAssignment>
-            Id = other.Id;
-            //  </OtherAssignment>
-            JoinPolicy = other.JoinPolicy;
-            Owner = other.Owner;
-            Members = other.Members;
-            // </OtherAssignmentList>
         }
 
         // <ColumnList>
@@ -89,7 +60,7 @@ namespace BSOA.Generator.Templates
         public Employee Owner
         {
             get => _table.Database.Employee.Get(_table.Owner[_index]);
-            set => _table.Owner[_index] = _table.Database.Employee.LocalIndex(value);
+            set => _table.Owner[_index] = value?.LocalIndex(_table) ?? -1;
         }
 
         //   </RefColumn>
@@ -183,12 +154,19 @@ namespace BSOA.Generator.Templates
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<Team>.Table => _table;
+        int IRow<Team>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(Team other)
         {
-            _index++;
+            // <OtherAssignmentList>
+            //  <OtherAssignment>
+            Id = other.Id;
+            //  </OtherAssignment>
+            JoinPolicy = other.JoinPolicy;
+            Owner = other.Owner;
+            Members = other.Members;
+            // </OtherAssignmentList>
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Generator/Templates/Team.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Team.cs
@@ -22,15 +22,14 @@ namespace BSOA.Generator.Templates
         public Team(Company root) : this(root.Database.Team)
         { }
 
-        public Team(Company root, Team other) : this(root.Database.Team, other)
-        { }
-
-        internal Team(TeamTable table) : this(table, table.Add()._index)
-        { }
-
-        internal Team(TeamTable table, Team other) : this(table ?? CompanyDatabase.Current.Team)
+        public Team(Company root, Team other) : this(root)
         {
             CopyFrom(other);
+        }
+
+        internal Team(TeamTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal Team(TeamTable table, int index)
@@ -38,6 +37,8 @@ namespace BSOA.Generator.Templates
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         // <ColumnList>
         //   <SimpleColumn>

--- a/csharp/BSOA/BSOA.Generator/Templates/Team.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Team.cs
@@ -110,11 +110,11 @@ namespace BSOA.Generator.Templates
 
             // <EqualsList>
             //  <Equals>
-            if (this.Id != other.Id) { return false; }
+            if (!object.Equals(this.Id, other.Id)) { return false; }
             //  </Equals>
-            if (this.JoinPolicy != other.JoinPolicy) { return false; }
-            if (this.Owner != other.Owner) { return false; }
-            if (this.Members != other.Members) { return false; }
+            if (!object.Equals(this.JoinPolicy, other.JoinPolicy)) { return false; }
+            if (!object.Equals(this.Owner, other.Owner)) { return false; }
+            if (!object.Equals(this.Members, other.Members)) { return false; }
             // </EqualsList>
 
             return true;

--- a/csharp/BSOA/BSOA.Generator/Templates/Team.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Team.cs
@@ -61,7 +61,7 @@ namespace BSOA.Generator.Templates
         public Employee Owner
         {
             get => _table.Database.Employee.Get(_table.Owner[_index]);
-            set => _table.Owner[_index] = _table.LocalIndex(value);
+            set => _table.Owner[_index] = _table.Database.Employee.LocalIndex(value);
         }
 
         //   </RefColumn>

--- a/csharp/BSOA/BSOA.Generator/Templates/Team.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Team.cs
@@ -22,7 +22,7 @@ namespace BSOA.Generator.Templates
         public Team(Company root) : this(root.Database.Team)
         { }
 
-        public Team(Company root, Team other) : this(root)
+        public Team(Company root, Team other) : this(root.Database.Team)
         {
             CopyFrom(other);
         }

--- a/csharp/BSOA/BSOA.Generator/Templates/Team.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Team.cs
@@ -61,7 +61,7 @@ namespace BSOA.Generator.Templates
         public Employee Owner
         {
             get => _table.Database.Employee.Get(_table.Owner[_index]);
-            set => _table.Owner[_index] = value?.LocalIndex(_table) ?? -1;
+            set => _table.Owner[_index] = _table.LocalIndex(value);
         }
 
         //   </RefColumn>

--- a/csharp/BSOA/BSOA.Generator/Templates/Team.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Team.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.Model;
 
 namespace BSOA.Generator.Templates
@@ -68,8 +69,8 @@ namespace BSOA.Generator.Templates
         //   <RefListColumn>
         public IList<Employee> Members
         {
-            get => _table.Database.Employee.List(_table.Members[_index]);
-            set => _table.Database.Employee.List(_table.Members[_index]).SetTo(value);
+            get => TypedList<Employee>.Get(_table.Database.Employee, _table.Members, _index);
+            set => TypedList<Employee>.Set(_table.Database.Employee, _table.Members, _index, value);
         }
 
         //   </RefListColumn>

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToBool.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToBool.cs
@@ -12,9 +12,9 @@ namespace BSOA.Json.Converters
             return (bool)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, bool item, bool defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, bool item, bool defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToDateTime.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToDateTime.cs
@@ -24,9 +24,9 @@ namespace BSOA.Json.Converters
             }
         }
 
-        public static void Write(JsonWriter writer, string propertyName, DateTime item, DateTime defaultValue = default(DateTime))
+        public static void Write(JsonWriter writer, string propertyName, DateTime item, DateTime defaultValue = default(DateTime), bool required = false)
         {
-            if (item.ToUniversalTime() != defaultValue.ToUniversalTime())
+            if (required || item.ToUniversalTime() != defaultValue.ToUniversalTime())
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item.ToUniversalTime().ToString(DateTimeFormat));

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToEnum.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToEnum.cs
@@ -15,9 +15,9 @@ namespace BSOA.Json.Converters
             return (TEnum)_enumConverter.ReadJson(reader, typeof(TEnum), null, null);
         }
 
-        public static void Write(JsonWriter writer, string propertyName, TEnum item, TEnum defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, TEnum item, TEnum defaultValue = default, bool required = false)
         {
-            if (!item.Equals(defaultValue))
+            if (required || !item.Equals(defaultValue))
             {
                 writer.WritePropertyName(propertyName);
                 _enumConverter.WriteJson(writer, item, null);

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToIDictionary.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToIDictionary.cs
@@ -34,9 +34,9 @@ namespace BSOA.Json.Converters
             return result;
         }
         
-        public static void Write(JsonWriter writer, string propertyName, IDictionary<string, TValue> dictionary, Action<JsonWriter, TValue> writeValue)
+        public static void Write(JsonWriter writer, string propertyName, IDictionary<string, TValue> dictionary, Action<JsonWriter, TValue> writeValue, bool required = false)
         {
-            if (dictionary?.Count > 0)
+            if (required || dictionary?.Count > 0)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, dictionary, writeValue);

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToIList.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToIList.cs
@@ -29,9 +29,9 @@ namespace BSOA.Json.Converters
             return result;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, IList<TItem> list, Action<JsonWriter, TItem> writeItem)
+        public static void Write(JsonWriter writer, string propertyName, IList<TItem> list, Action<JsonWriter, TItem> writeItem, bool required = false)
         {
-            if (list?.Count > 0)
+            if (required || list?.Count > 0)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, list, writeItem);

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToNumbers.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToNumbers.cs
@@ -19,9 +19,9 @@ namespace BSOA.Json.Converters
             return (byte)(long)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, byte item, byte defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, byte item, byte defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -46,9 +46,9 @@ namespace BSOA.Json.Converters
             return (sbyte)(long)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, sbyte item, sbyte defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, sbyte item, sbyte defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -73,9 +73,9 @@ namespace BSOA.Json.Converters
             return (short)(long)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, short item, short defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, short item, short defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -100,9 +100,9 @@ namespace BSOA.Json.Converters
             return (ushort)(long)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, ushort item, ushort defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, ushort item, ushort defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -127,9 +127,9 @@ namespace BSOA.Json.Converters
             return (int)(long)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, int item, int defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, int item, int defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -154,9 +154,9 @@ namespace BSOA.Json.Converters
             return (uint)(long)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, uint item, uint defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, uint item, uint defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -181,9 +181,9 @@ namespace BSOA.Json.Converters
             return (long)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, long item, long defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, long item, long defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -215,9 +215,9 @@ namespace BSOA.Json.Converters
             }
         }
 
-        public static void Write(JsonWriter writer, string propertyName, ulong item, ulong defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, ulong item, ulong defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -242,9 +242,9 @@ namespace BSOA.Json.Converters
             return (float)(double)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, float item, float defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, float item, float defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);
@@ -269,9 +269,9 @@ namespace BSOA.Json.Converters
             return (double)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, double item, double defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, double item, double defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToString.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToString.cs
@@ -17,9 +17,9 @@ namespace BSOA.Json.Converters
             return (string)reader.Value;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, string item, string defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, string item, string defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToUri.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToUri.cs
@@ -26,9 +26,9 @@ namespace BSOA.Json.Converters
             }
         }
 
-        public static void Write(JsonWriter writer, string propertyName, Uri item, Uri defaultValue = default)
+        public static void Write(JsonWriter writer, string propertyName, Uri item, Uri defaultValue = default, bool required = false)
         {
-            if (item != defaultValue)
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item?.OriginalString);

--- a/csharp/BSOA/BSOA.Test/CollectionReadVerifier.cs
+++ b/csharp/BSOA/BSOA.Test/CollectionReadVerifier.cs
@@ -165,5 +165,14 @@ namespace BSOA.Test
 
             Assert.False(aUntyped.MoveNext());
         }
+
+        public static void VerifyEqualityMembers<T>(T value, T equivalent) where T : class
+        {
+            Assert.True(value.Equals(value));
+            Assert.True(value.Equals(equivalent));
+
+            Assert.Equal(value.GetHashCode(), value.GetHashCode());
+            Assert.Equal(value.GetHashCode(), equivalent.GetHashCode());
+        }
     }
 }

--- a/csharp/BSOA/BSOA.Test/CollectionReadVerifier.cs
+++ b/csharp/BSOA/BSOA.Test/CollectionReadVerifier.cs
@@ -12,6 +12,12 @@ namespace BSOA.Test
     {
         public static void VerifySame<T>(IEnumerable<T> expected, IEnumerable<T> actual, bool quick = false)
         {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
             if (actual is IList<T> && expected is IList<T>)
             {
                 VerifyList((IList<T>)expected, (IList<T>)actual, quick);
@@ -36,6 +42,12 @@ namespace BSOA.Test
 
         public static void VerifyList<T>(IList<T> expected, IList<T> actual, bool quick = false)
         {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
             // Verify Counts match
             Assert.Equal(expected.Count, actual.Count);
 
@@ -53,6 +65,12 @@ namespace BSOA.Test
 
         public static void VerifyReadOnlyList<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual, bool quick = false)
         {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
             // Verify Counts match
             Assert.Equal(expected.Count, actual.Count);
 
@@ -62,14 +80,20 @@ namespace BSOA.Test
                 Assert.Equal(expected[i], actual[i]);
             }
 
-            if (!quick) 
-            { 
-                VerifyReadOnlyCollection<T>(expected, actual); 
+            if (!quick)
+            {
+                VerifyReadOnlyCollection<T>(expected, actual);
             }
         }
 
         public static void VerifyCollection<T>(ICollection<T> expected, ICollection<T> actual)
         {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
             Assert.Equal(expected.Count, actual.Count);
 
             VerifyEnumerable<T>(expected, actual);
@@ -77,6 +101,12 @@ namespace BSOA.Test
 
         public static void VerifyReadOnlyCollection<T>(IReadOnlyCollection<T> expected, IReadOnlyCollection<T> actual)
         {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
             Assert.Equal(expected.Count, actual.Count);
 
             VerifyEnumerable<T>(expected, actual);
@@ -84,6 +114,12 @@ namespace BSOA.Test
 
         public static void VerifyEnumerable<T>(IEnumerable<T> expected, IEnumerable<T> actual)
         {
+            if (expected == null)
+            {
+                Assert.Null(actual);
+                return;
+            }
+
             // Verify typed enumerator (MoveNext, Current, Reset)
             using (IEnumerator<T> eTyped = expected.GetEnumerator())
             using (IEnumerator<T> aTyped = actual.GetEnumerator())
@@ -110,7 +146,7 @@ namespace BSOA.Test
             // Verify untyped enumerator
             IEnumerator eUntyped = ((IEnumerable)expected).GetEnumerator();
             IEnumerator aUntyped = ((IEnumerable)actual).GetEnumerator();
-            
+
             while (eUntyped.MoveNext())
             {
                 Assert.True(aUntyped.MoveNext());

--- a/csharp/BSOA/BSOA.Test/Collections/ColumnDictionaryTests.cs
+++ b/csharp/BSOA/BSOA.Test/Collections/ColumnDictionaryTests.cs
@@ -91,23 +91,18 @@ namespace BSOA.Test.Collections
             row2[secondName] = secondValue;
             row2[sampleName] = sampleValue;
 
-            // Equals (order-independent)
-            Assert.True(row.Equals(row));
-            Assert.True(row.Equals(row2));
-            Assert.False(row.Equals(ColumnDictionary<string, string>.Empty));
-            Assert.False(row.Equals(null));
+            // Test Equals and GetHashCode
+            CollectionReadVerifier.VerifyEqualityMembers<ColumnDictionary<string, string>>(row, row2);
 
-            // Operators
+            // Test equality operators
             Assert.True(row == row2);
-            Assert.False(row == ColumnDictionary<string, string>.Empty);
-            Assert.True(ColumnDictionary<string, string>.Empty != row);
-            Assert.False(row2 != row);
-            Assert.True((ColumnDictionary<string, string>)null == null);
-            Assert.False((ColumnDictionary<string, string>)null != null);
+            Assert.False(row != row2);
 
-            // GetHashCode (order-independent)
-            Assert.Equal(row.GetHashCode(), row2.GetHashCode());
-            Assert.NotEqual(row.GetHashCode(), ColumnDictionary<string, string>.Empty.GetHashCode());
+            Assert.False(row == null);
+            Assert.True(row != null);
+
+            Assert.False(null == row);
+            Assert.True(null != row);
 
             // GetHashCode handles null key/values safely
             row[null] = null;

--- a/csharp/BSOA/BSOA.Test/Collections/ColumnDictionaryTests.cs
+++ b/csharp/BSOA/BSOA.Test/Collections/ColumnDictionaryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 using BSOA.Collections;
 
@@ -116,7 +117,10 @@ namespace BSOA.Test.Collections
             // NOTE: Must use unique keys, because Add(KeyValuePair) will throw for a duplicate key
             CollectionChangeVerifier.VerifyCollection(row, (i) => new KeyValuePair<string, string>(i.ToString(), i.ToString()));
 
-            Assert.Throws<IndexOutOfRangeException>(() => new ColumnDictionary<string, string>(null, -1));
+            if (!Debugger.IsAttached)
+            {
+                Assert.Throws<IndexOutOfRangeException>(() => new ColumnDictionary<string, string>(null, -1));
+            }
         }
     }
 }

--- a/csharp/BSOA/BSOA.Test/Collections/ColumnDictionaryTests.cs
+++ b/csharp/BSOA/BSOA.Test/Collections/ColumnDictionaryTests.cs
@@ -119,7 +119,7 @@ namespace BSOA.Test.Collections
 
             if (!Debugger.IsAttached)
             {
-                Assert.Throws<IndexOutOfRangeException>(() => new ColumnDictionary<string, string>(null, -1));
+                Assert.Throws<IndexOutOfRangeException>(() => ColumnDictionary<string, string>.Get(null, -1));
             }
         }
     }

--- a/csharp/BSOA/BSOA.Test/Collections/TypedListTests.cs
+++ b/csharp/BSOA/BSOA.Test/Collections/TypedListTests.cs
@@ -1,6 +1,8 @@
 ﻿using BSOA.Collections;
 using BSOA.Column;
+using BSOA.Test.Model.V1;
 
+using System;
 using System.Collections.Generic;
 
 using Xunit;
@@ -10,38 +12,50 @@ namespace BSOA.Test.Collections
     public class TypedListTests
     {
         [Fact]
-        public void TypeList_Basics()
+        public void TypedList_Basics()
         {
-            List<string> strings = new List<string> { "One", "Two", "Three" };
+            Community c = new Community();
 
-            NumberListColumn<int> column = new NumberListColumn<int>();
-            TypedList<string> list = new TypedList<string>(column[0], (i) => strings[i], (text) => strings.IndexOf(text));
+            List<Person> people = new List<Person> 
+            {
+                new Person(c) { Name = "One" },
+                new Person(c) { Name = "Two" },
+                new Person(c) { Name = "Three" }
+            };
 
+            // Null by default
+            Assert.Null(c.People);
+            
+            // Settable to Empty
+            c.People = Array.Empty<Person>();
+            
+            TypedList<Person> list = (TypedList<Person>)c.People;
             Assert.Empty(list);
 
-            list.Add("One");
+            list.Add(people[0]);
             Assert.Single(list);
-            Assert.Equal(0, column[0][0]);
 
-            list.Add("Two");
-            Assert.True(list.Equals(new string[] { "One", "Two" }));
-            Assert.Equal(1, column[0][1]);
+            list.Add(people[1]);
+            list.Add(people[2]);
+            CollectionReadVerifier.VerifySame(people, list);
 
             // SetTo self works properly
             list.SetTo(list);
-            Assert.True(list.Equals(new string[] { "One", "Two" }));
-
-            // SetTo other works
-            list.SetTo(new List<string>() { "One" });
-            Assert.True(list.Equals(new string[] { "One" }));
-
-            // SetTo empty works
-            list.SetTo(new string[0]);
-            Assert.Empty(list);
+            CollectionReadVerifier.VerifySame(people, list);
 
             // SetTo null works
             list.SetTo(null);
             Assert.Empty(list);
+
+            // SetTo other works
+            list.SetTo(people);
+            CollectionReadVerifier.VerifySame(people, list);
+
+            // SetTo empty works
+            list.SetTo(new List<Person>());
+            Assert.Empty(list);
+
+            CollectionChangeVerifier.VerifyList(c.People, (i) => new Person(c) { Age = (byte)i });
         }
     }
 }

--- a/csharp/BSOA/BSOA.Test/Collections/TypedListTests.cs
+++ b/csharp/BSOA/BSOA.Test/Collections/TypedListTests.cs
@@ -1,0 +1,47 @@
+﻿using BSOA.Collections;
+using BSOA.Column;
+
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace BSOA.Test.Collections
+{
+    public class TypedListTests
+    {
+        [Fact]
+        public void TypeList_Basics()
+        {
+            List<string> strings = new List<string> { "One", "Two", "Three" };
+
+            NumberListColumn<int> column = new NumberListColumn<int>();
+            TypedList<string> list = new TypedList<string>(column[0], (i) => strings[i], (text) => strings.IndexOf(text));
+
+            Assert.Empty(list);
+
+            list.Add("One");
+            Assert.Single(list);
+            Assert.Equal(0, column[0][0]);
+
+            list.Add("Two");
+            Assert.True(list.Equals(new string[] { "One", "Two" }));
+            Assert.Equal(1, column[0][1]);
+
+            // SetTo self works properly
+            list.SetTo(list);
+            Assert.True(list.Equals(new string[] { "One", "Two" }));
+
+            // SetTo other works
+            list.SetTo(new List<string>() { "One" });
+            Assert.True(list.Equals(new string[] { "One" }));
+
+            // SetTo empty works
+            list.SetTo(new string[0]);
+            Assert.Empty(list);
+
+            // SetTo null works
+            list.SetTo(null);
+            Assert.Empty(list);
+        }
+    }
+}

--- a/csharp/BSOA/BSOA.Test/Collections/TypedListTests.cs
+++ b/csharp/BSOA/BSOA.Test/Collections/TypedListTests.cs
@@ -51,11 +51,32 @@ namespace BSOA.Test.Collections
             list.SetTo(people);
             CollectionReadVerifier.VerifySame(people, list);
 
+            // Test Equality members
+            CollectionReadVerifier.VerifyEqualityMembers(list, list);
+
+            // Test equality operators
+#pragma warning disable CS1718 // Comparison made to same variable
+            Assert.True(list == list);
+            Assert.False(list != list);
+#pragma warning restore CS1718 // Comparison made to same variable
+
+            Assert.False(list == null);
+            Assert.True(list != null);
+
+            Assert.False(null == list);
+            Assert.True(null != list);
+
             // SetTo empty works
             list.SetTo(new List<Person>());
             Assert.Empty(list);
 
             CollectionChangeVerifier.VerifyList(c.People, (i) => new Person(c) { Age = (byte)i });
+
+            // Set null
+            IList<Person> cachedPeople = c.People;
+            c.People = null;
+            Assert.Null(c.People);
+            Assert.Equal(0, cachedPeople.Count);
         }
     }
 }

--- a/csharp/BSOA/BSOA.Test/Column.cs
+++ b/csharp/BSOA/BSOA.Test/Column.cs
@@ -99,6 +99,10 @@ namespace BSOA.Test
             column[1] = valueProvider(1);
             Assert.Equal(valueProvider(1), column[1]);
 
+            // Set to self
+            column[1] = column[1];
+            Assert.Equal(valueProvider(1), column[1]);
+
             // Add() without instance
             T item = column.Add();
             Assert.Equal(defaultValue, item);
@@ -197,6 +201,9 @@ namespace BSOA.Test
             {
                 // Verify indexer range check (< 0 only; columns auto-size for bigger values)
                 Assert.Throws<IndexOutOfRangeException>(() => column[-1]);
+
+                // Verify indexer range check (< 0 only; columns auto-size for bigger values)
+                Assert.Throws<IndexOutOfRangeException>(() => column[-1] = defaultValue);
 
                 // Verify Remove throws (not expected to be implemented)
                 Assert.Throws<NotSupportedException>(() => column.Remove(defaultValue));

--- a/csharp/BSOA/BSOA.Test/Column/DateTimeColumnTests.cs
+++ b/csharp/BSOA/BSOA.Test/Column/DateTimeColumnTests.cs
@@ -23,6 +23,15 @@ namespace BSOA.Test
                 otherValue,
                 (i) => otherValue.AddDays(-i)
             );
+
+            // Support both DateTime.MinValue and DateTime.MinValue.ToUniversalTime() as successfully roundtripped defaults
+            defaultValue = DateTime.MinValue;
+            Column.Basics<DateTime>(
+                () => new DateTimeColumn(defaultValue),
+                defaultValue,
+                otherValue,
+                (i) => otherValue.AddDays(-i)
+            );
         }
     }
 }

--- a/csharp/BSOA/BSOA.Test/Column/DictionaryColumnTests.cs
+++ b/csharp/BSOA/BSOA.Test/Column/DictionaryColumnTests.cs
@@ -16,7 +16,8 @@ namespace BSOA.Test
         {
             DictionaryColumn<string, string> column = new DictionaryColumn<string, string>(
                 new DistinctColumn<string>(new StringColumn(), null),
-                new StringColumn());
+                new StringColumn(),
+                nullByDefault: false);
 
             ColumnDictionary<string, string> first = (ColumnDictionary<string, string>)column[0];
             first["One"] = "One";
@@ -28,7 +29,7 @@ namespace BSOA.Test
         [Fact]
         public void DictionaryColumn_Basics()
         {
-            DictionaryColumn<string, string> scratch = new DictionaryColumn<string, string>(new StringColumn(), new StringColumn());
+            DictionaryColumn<string, string> scratch = new DictionaryColumn<string, string>(new StringColumn(), new StringColumn(), nullByDefault: false);
             ColumnDictionary<string, string> defaultValue = ColumnDictionary<string, string>.Empty;
 
             ColumnDictionary<string, string> otherValue = SampleRow();
@@ -41,7 +42,28 @@ namespace BSOA.Test
             Column.Basics<IDictionary<string, string>>(
                 () => new DictionaryColumn<string, string>(
                     new DistinctColumn<string>(new StringColumn()),
-                    new StringColumn()),
+                    new StringColumn(),
+                    nullByDefault: false),
+                defaultValue,
+                otherValue,
+                (i) =>
+                {
+                    if (scratch[i].Count == 0)
+                    {
+                        scratch[i][(i % 10).ToString()] = i.ToString();
+                        scratch[i][((i + 1) % 10).ToString()] = i.ToString();
+                    }
+
+                    return scratch[i];
+                }
+            );
+
+            defaultValue = null;
+            Column.Basics<IDictionary<string, string>>(
+                () => new DictionaryColumn<string, string>(
+                    new DistinctColumn<string>(new StringColumn()),
+                    new StringColumn(),
+                    nullByDefault: true),
                 defaultValue,
                 otherValue,
                 (i) =>

--- a/csharp/BSOA/BSOA.Test/Column/DictionaryColumnTests.cs
+++ b/csharp/BSOA/BSOA.Test/Column/DictionaryColumnTests.cs
@@ -18,7 +18,11 @@ namespace BSOA.Test
                 new DistinctColumn<string>(new StringColumn(), null),
                 new StringColumn());
 
-            return (ColumnDictionary<string, string>)column[0];
+            ColumnDictionary<string, string> first = (ColumnDictionary<string, string>)column[0];
+            first["One"] = "One";
+            first["Two"] = "Two";
+
+            return (ColumnDictionary<string, string>)column[1];
         }
 
         [Fact]

--- a/csharp/BSOA/BSOA.Test/Column/NumberListColumnTests.cs
+++ b/csharp/BSOA/BSOA.Test/Column/NumberListColumnTests.cs
@@ -100,55 +100,5 @@ namespace BSOA.Test
             // Column range check
             Assert.Throws<IndexOutOfRangeException>(() => column[-1]);
         }
-
-        [Fact]
-        public void NumberListColumn_TypeList_Basics()
-        {
-            // Set up column with sample values, roundtrip, re-verify
-            NumberListColumn<int> column = BuildSampleColumn();
-
-            // Verify second value is in a shared array, not at index zero, not expandable (yet), not ReadOnly
-            NumberList<int> row1List = column[1];
-            TypedList<int> row1Typed = new TypedList<int>(row1List, (index) => index, (index) => index);
-
-            // Test second sample row slice IList members on NumberListConverter
-            CollectionChangeVerifier.VerifyList(row1Typed, (index) => index % 20);
-
-            // Verify values are re-merged and re-loaded properly
-            string values = string.Join(", ", row1List);
-            column = TreeSerializer.RoundTrip(column, TreeFormat.Binary);
-            Assert.Equal(values, string.Join(", ", column[1]));
-
-            // TypedList Equality
-            TypedList<int> row1 = new TypedList<int>(column[1], (index) => index, (index) => index);
-            TypedList<int> row0 = new TypedList<int>(column[0], (index) => index, (index) => index);
-            Assert.True(row1.Equals(row1));
-            Assert.False(row1.Equals(row0));
-            Assert.False(row1 == row0);
-            Assert.True(row1 != row0);
-            Assert.False(null == row0);
-            Assert.True(null != row0);
-            Assert.Equal(row1.GetHashCode(), row1.GetHashCode());
-
-            // TypedList.Indices
-            Assert.Equal(row1.Indices, column[1]);
-
-            // SetTo(other)
-            TypedList<int> firstRow = new TypedList<int>(column[0], (index) => index, (index) => index);
-            row1Typed.SetTo(firstRow);
-            Assert.Equal(string.Join(", ", firstRow), string.Join(", ", row1Typed));
-
-            // SetTo(null)
-            row1Typed.SetTo(null);
-            Assert.Empty(row1Typed);
-
-            // SetTo(IList)
-            row1Typed.SetTo(new int[] { 2, 3, 4, 5 });
-            Assert.Equal("2, 3, 4, 5", string.Join(", ", row1Typed));
-
-            // SetTo(empty)
-            row1Typed.SetTo(Array.Empty<int>());
-            Assert.Empty(row1Typed);
-        }
     }
 }

--- a/csharp/BSOA/BSOA.Test/ColumnFactoryTests.cs
+++ b/csharp/BSOA/BSOA.Test/ColumnFactoryTests.cs
@@ -40,6 +40,16 @@ namespace BSOA.Test
             IColumn<IDictionary<string, string>> dictionaryColumn = (IColumn<IDictionary<string, string>>)(ColumnFactory.Build(typeof(IDictionary<string, string>), null));
             Assert.NotNull(dictionaryColumn);
 
+            // Verify collections are null by default if null passed as default
+            Assert.Null(listColumn[0]);
+            Assert.Null(dictionaryColumn[0]);
+
+            // Verify collections not null by default if non-null passed as default
+            listColumn = (IColumn<IList<string>>)ColumnFactory.Build(typeof(IList<string>), new object());
+            dictionaryColumn = (IColumn<IDictionary<string, string>>)(ColumnFactory.Build(typeof(IDictionary<string, string>), new object()));
+            Assert.NotNull(listColumn[0]);
+            Assert.NotNull(dictionaryColumn[0]);
+
             if (!Debugger.IsAttached)
             {
                 Assert.Throws<NotImplementedException>(() => ColumnFactory.Build(typeof(Decimal)));

--- a/csharp/BSOA/BSOA.Test/Json/ConvertersTests.cs
+++ b/csharp/BSOA/BSOA.Test/Json/ConvertersTests.cs
@@ -30,7 +30,7 @@ namespace BSOA.Test.Json
 
             JsonRoundTrip.ValueOnly(now, JsonToDateTime.Write, JsonToDateTime.Read);
 
-            JsonRoundTrip.NameAndValue(now, DateTime.MinValue, JsonToDateTime.Write, JsonToDateTime.Read);
+            JsonRoundTrip.NameAndValue(now, DateTime.MinValue.ToUniversalTime(), JsonToDateTime.Write, JsonToDateTime.Read);
             JsonRoundTrip.NameAndValue(ToMillisecond(DateTime.MinValue.ToUniversalTime()), now, JsonToDateTime.Write, JsonToDateTime.Read);
             JsonRoundTrip.NameAndValue(ToMillisecond(DateTime.MaxValue.ToUniversalTime()), now, JsonToDateTime.Write, JsonToDateTime.Read);
 

--- a/csharp/BSOA/BSOA.Test/Json/GeneratedConverterTests.cs
+++ b/csharp/BSOA/BSOA.Test/Json/GeneratedConverterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 
 using BSOA.Json;
 using BSOA.Test.Model.V2;
@@ -43,9 +44,10 @@ namespace BSOA.Test.Json
             string communityPath = "Community.NewtonsoftDefault.json";
             AsJson.Save(communityPath, readRoot);
             Community roundTripCommunity = AsJson.Load<Community>(communityPath);
-            Assert.Empty(roundTripCommunity.People);
+            Assert.Null(roundTripCommunity.People);
 
             // Serialize root with Person
+            readRoot.People = new List<Person>();
             readRoot.People.Add(p);
             AsJson.Save(communityPath, readRoot);
             roundTripCommunity = AsJson.Load<Community>(communityPath);

--- a/csharp/BSOA/BSOA.Test/Json/GeneratedConverterTests.cs
+++ b/csharp/BSOA/BSOA.Test/Json/GeneratedConverterTests.cs
@@ -21,7 +21,7 @@ namespace BSOA.Test.Json
             // Serialization via typed methods
             JsonRoundTrip.ValueOnly(p, JsonToPerson.Write, (r, db) => JsonToPerson.Read(r, readRoot));
             JsonRoundTrip.ValueOnly(null, JsonToPerson.Write, (r, db) => JsonToPerson.Read(r, readRoot));
-            JsonRoundTrip.NameAndValue(p, null, (w, pn, v, dv) => JsonToPerson.Write(w, pn, v), (r, db) => JsonToPerson.Read(r, readRoot));
+            JsonRoundTrip.NameAndValue(p, null, (w, pn, v, dv, req) => JsonToPerson.Write(w, pn, v, req), (r, db) => JsonToPerson.Read(r, readRoot));
 
             // JsonConverter.CanConvert (not called by default serialization)
             JsonToPerson converter = new JsonToPerson();

--- a/csharp/BSOA/BSOA.Test/Json/JsonToIDictionaryTests.cs
+++ b/csharp/BSOA/BSOA.Test/Json/JsonToIDictionaryTests.cs
@@ -20,12 +20,13 @@ namespace BSOA.Test.Json
         public void JsonToIDictionary_Basics()
         {
             Action<JsonWriter, IDictionary<string, string>> writeValueOnly = (w, v) => JsonToIDictionary<string, string>.Write(w, v, JsonToString.Write);
-            Action<JsonWriter, string, IDictionary<string, string>, IDictionary<string, string>> writeNameAndValue = (w, pn, v, dv) => JsonToIDictionary<string, string>.Write(w, pn, v, JsonToString.Write);
+            Action<JsonWriter, string, IDictionary<string, string>, IDictionary<string, string>, bool> writeNameAndValue = (w, pn, v, dv, r) => JsonToIDictionary<string, string>.Write(w, pn, v, JsonToString.Write, r);
 
             // Dictionaries can be read by taking the return value or passing a Dictionary to fill as the argument
             Func<JsonReader, Database, IDictionary<string, string>> readViaReturnValue = (r, db) => JsonToIDictionary<string, string>.Read(r, db, null, JsonToString.Read);
             Func<JsonReader, Database, IDictionary<string, string>> readViaArgument = (r, db) =>
             {
+                if (r.TokenType == JsonToken.Null) { return null; }
                 IDictionary<string, string> result = new Dictionary<string, string>();
                 JsonToIDictionary<string, string>.Read(r, db, result, JsonToString.Read);
                 return result;

--- a/csharp/BSOA/BSOA.Test/Json/JsonToIListTests.cs
+++ b/csharp/BSOA/BSOA.Test/Json/JsonToIListTests.cs
@@ -19,12 +19,13 @@ namespace BSOA.Test.Json
         public void JsonToIList_Basics()
         {
             Action<JsonWriter, IList<int>> writeValueOnly = (w, v) => JsonToIList<int>.Write(w, v, JsonToInt.Write);
-            Action<JsonWriter, string, IList<int>, IList<int>> writeNameAndValue = (w, pn, v, dv) => JsonToIList<int>.Write(w, pn, v, JsonToInt.Write);
+            Action<JsonWriter, string, IList<int>, IList<int>, bool> writeNameAndValue = (w, pn, v, dv, r) => JsonToIList<int>.Write(w, pn, v, JsonToInt.Write, r);
 
             // Lists can be read either by taking the return value, or by passing a list to fill as the argument
             Func<JsonReader, Database, IList<int>> readViaReturnValue = (r, db) => JsonToIList<int>.Read(r, db, null, JsonToInt.Read);
             Func<JsonReader, Database, IList<int>> readViaArgument = (r, db) =>
             {
+                if (r.TokenType == JsonToken.Null) { return null; }
                 IList<int> result = new List<int>();
                 JsonToIList<int>.Read(r, db, result, JsonToInt.Read);
                 return result;

--- a/csharp/BSOA/BSOA.Test/Model/DatabaseTests.cs
+++ b/csharp/BSOA/BSOA.Test/Model/DatabaseTests.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
-using System.Text;
+using System.Runtime.CompilerServices;
 
 using BSOA.IO;
 using BSOA.Json;
@@ -46,6 +47,12 @@ namespace BSOA.Test.Model
             // Verify Trim doesn't throw (results not visible)
             community.DB.Trim();
             CollectionReadVerifier.VerifySame(community.People, roundTripped.People);
+
+            // Verify Copy constructor recursively copies (List.SetTo -> LocalIndex -> CopyFrom construction)
+            V1.Community copy = new V1.Community(community);
+            CollectionReadVerifier.VerifySame(community.People, copy.People);
+            community.People[0].Age += 10;
+            Assert.NotEqual(community.People[0].Age, copy.People[0].Age);
 
             // Verify Database.Clear works
             community.DB.Clear();
@@ -98,7 +105,10 @@ namespace BSOA.Test.Model
             Assert.Equal(0, v1RoundTrip.People[0].Age);
 
             // Read with TreeSerializationSettings.Strict and verify error
-            Assert.Throws<IOException>(() => v1RoundTrip.DB.Load(filePath, TreeFormat.Binary, new BSOA.IO.TreeSerializationSettings() { Strict = true }));
+            if (Debugger.IsAttached)
+            {
+                Assert.Throws<IOException>(() => v1RoundTrip.DB.Load(filePath, TreeFormat.Binary, new BSOA.IO.TreeSerializationSettings() { Strict = true }));
+            }
         }
 
         [Fact]

--- a/csharp/BSOA/BSOA.Test/Model/DatabaseTests.cs
+++ b/csharp/BSOA/BSOA.Test/Model/DatabaseTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -20,6 +21,8 @@ namespace BSOA.Test.Model
         public void Database_Basics()
         {
             V1.Community community = new V1.Community();
+            community.People = new List<V1.Person>();
+
             community.People.Add(new V1.Person() { Age = 39, Name = "Scott" });
             community.People.Add(new V1.Person() { Age = 36, Name = "Adam" });
 
@@ -56,7 +59,7 @@ namespace BSOA.Test.Model
 
             // Verify Database.Clear works
             community.DB.Clear();
-            Assert.Empty(community.People);
+            Assert.Null(community.People);
         }
 
         [Fact]
@@ -65,6 +68,8 @@ namespace BSOA.Test.Model
             // Test saving a database and then loading it into a different object model with added and removed columns.
             
             V1.Community v1 = new V1.Community();
+            v1.People = new List<V1.Person>();
+
             v1.People.Add(new V1.Person() { Age = 39, Name = "Scott" });
             v1.People.Add(new V1.Person() { Age = 36, Name = "Adam" });
 
@@ -118,6 +123,8 @@ namespace BSOA.Test.Model
             // These use generated JsonConverter classes to serialize using safe constructors and good default behaviors.
 
             V1.Community v1 = new V1.Community();
+            v1.People = new List<V1.Person>();
+
             v1.People.Add(new V1.Person() { Age = 39, Name = "Scott" });
             v1.People.Add(new V1.Person() { Age = 36, Name = "Adam" });
 

--- a/csharp/BSOA/BSOA.Test/Model/TableTests.cs
+++ b/csharp/BSOA/BSOA.Test/Model/TableTests.cs
@@ -3,6 +3,8 @@
 
 using BSOA.Test.Model.V1;
 
+using System.Collections.Generic;
+
 using Xunit;
 
 namespace BSOA.Test.Model
@@ -43,21 +45,24 @@ namespace BSOA.Test.Model
         {
             V1.Community other = new V1.Community();
             V1.Community v1 = new V1.Community();
-           
+
+            v1.People = new List<Person>();
+            IList<Person> people = v1.People;
+
             // Add item already in correct instance
-            v1.People.Add(new V1.Person(v1) { Age = 39, Name = "Scott" });
-            Assert.Equal("Scott", v1.People[0].Name);
+            people.Add(new V1.Person(v1) { Age = 39, Name = "Scott" });
+            Assert.Equal("Scott", people[0].Name);
 
             // Add item copied from other instance
-            v1.People.Add(new V1.Person(other) { Age = 36, Name = "Adam" });
-            Assert.Equal("Adam", v1.People[1].Name);
+            people.Add(new V1.Person(other) { Age = 36, Name = "Adam" });
+            Assert.Equal("Adam", people[1].Name);
 
             // Try setter from other DB
             V1.Person dave = new V1.Person(other) { Age = 45, Name = "Dave" };
-            Assert.Equal(2, v1.People.Count);
-            v1.People[1] = dave;
-            Assert.Equal(2, v1.People.Count);
-            Assert.Equal("Dave", v1.People[1].Name);
+            Assert.Equal(2, people.Count);
+            people[1] = dave;
+            Assert.Equal(2, people.Count);
+            Assert.Equal("Dave", people[1].Name);
 
             // Set to already correct instance
             v1.People[1] = v1.People[1];

--- a/csharp/BSOA/BSOA.Test/Model/TableTests.cs
+++ b/csharp/BSOA/BSOA.Test/Model/TableTests.cs
@@ -32,9 +32,9 @@ namespace BSOA.Test.Model
             other[1] = other[1];
             Assert.Equal(name, other[1].Name);
 
-            // Verify Add detects already in this table item
+            // Verify Add detects already is last Table item
             int count = other.Count;
-            other.Add(other[1]);
+            other.Add(other[count - 1]);
             Assert.Equal(count, other.Count);
         }
 

--- a/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 using BSOA.IO;
 using BSOA.Model;
@@ -106,7 +105,7 @@ namespace BSOA.Test.Model.V1
         #endregion
 
         #region Easy Serialization
-        public void WriteBsoa(Stream stream)
+        public void WriteBsoa(System.IO.Stream stream)
         {
             using (BinaryTreeWriter writer = new BinaryTreeWriter(stream))
             {
@@ -116,10 +115,10 @@ namespace BSOA.Test.Model.V1
 
         public void WriteBsoa(string filePath)
         {
-            WriteBsoa(File.Create(filePath));
+            WriteBsoa(System.IO.File.Create(filePath));
         }
 
-        public static Community ReadBsoa(Stream stream)
+        public static Community ReadBsoa(System.IO.Stream stream)
         {
             using (BinaryTreeReader reader = new BinaryTreeReader(stream))
             {
@@ -131,15 +130,15 @@ namespace BSOA.Test.Model.V1
 
         public static Community ReadBsoa(string filePath)
         {
-            return ReadBsoa(File.OpenRead(filePath));
+            return ReadBsoa(System.IO.File.OpenRead(filePath));
         }
 
         public static TreeDiagnostics Diagnostics(string filePath)
         {
-            return Diagnostics(File.OpenRead(filePath));
+            return Diagnostics(System.IO.File.OpenRead(filePath));
         }
 
-        public static TreeDiagnostics Diagnostics(Stream stream)
+        public static TreeDiagnostics Diagnostics(System.IO.Stream stream)
         {
             using (BinaryTreeReader btr = new BinaryTreeReader(stream))
             using (TreeDiagnosticsReader reader = new TreeDiagnosticsReader(btr))

--- a/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.IO;
 using BSOA.Model;
 
@@ -43,8 +44,8 @@ namespace BSOA.Test.Model.V1
 
         public IList<Person> People
         {
-            get => _table.Database.Person.List(_table.People[_index]);
-            set => _table.Database.Person.List(_table.People[_index]).SetTo(value);
+            get => TypedList<Person>.Get(_table.Database.Person, _table.People, _index);
+            set => TypedList<Person>.Set(_table.Database.Person, _table.People, _index, value);
         }
 
         #region IEquatable<Community>

--- a/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
@@ -12,10 +12,10 @@ namespace BSOA.Test.Model.V1
     /// <summary>
     ///  BSOA GENERATED Root Entity for 'Community'
     /// </summary>
-    public partial class Community : IRow
+    public partial class Community : IRow<Community>, IEquatable<Community>
     {
-        private CommunityTable _table;
-        private int _index;
+        private readonly CommunityTable _table;
+        private readonly int _index;
 
         internal PersonDatabase Database => _table.Database;
         public ITreeSerializable DB => _table.Database;
@@ -23,9 +23,15 @@ namespace BSOA.Test.Model.V1
         public Community() : this(new PersonDatabase().Community)
         { }
 
-        internal Community(CommunityTable table) : this(table, table.Count)
+        public Community(Community other) : this(new PersonDatabase().Community, other)
+        { }
+
+        internal Community(CommunityTable table) : this(table, table.Add()._index)
+        { }
+
+        internal Community(CommunityTable table, Community other) : this(table)
         {
-            table.Add();
+            CopyFrom(other);
         }
 
         internal Community(CommunityTable table, int index)
@@ -39,7 +45,6 @@ namespace BSOA.Test.Model.V1
             get => _table.Database.Person.List(_table.People[_index]);
             set => _table.Database.Person.List(_table.People[_index]).SetTo(value);
         }
-
 
         #region IEquatable<Community>
         public bool Equals(Community other)
@@ -95,12 +100,12 @@ namespace BSOA.Test.Model.V1
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<Community>.Table => _table;
+        int IRow<Community>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(Community other)
         {
-            _index++;
+            People = other.People;
         }
         #endregion
 

--- a/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
@@ -23,15 +23,14 @@ namespace BSOA.Test.Model.V1
         public Community() : this(new PersonDatabase().Community)
         { }
 
-        public Community(Community other) : this(new PersonDatabase().Community, other)
-        { }
-
-        internal Community(CommunityTable table) : this(table, table.Add()._index)
-        { }
-
-        internal Community(CommunityTable table, Community other) : this(table)
+        public Community(Community other) : this(new PersonDatabase().Community)
         {
             CopyFrom(other);
+        }
+
+        internal Community(CommunityTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal Community(CommunityTable table, int index)
@@ -39,6 +38,8 @@ namespace BSOA.Test.Model.V1
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         public IList<Person> People
         {

--- a/csharp/BSOA/BSOA.Test/Model/V1/Json/JsonToCommunity.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Json/JsonToCommunity.cs
@@ -39,9 +39,9 @@ namespace BSOA.Test.Model.V1
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, Community item)
+        public static void Write(JsonWriter writer, string propertyName, Community item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Test/Model/V1/Json/JsonToCommunity.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Json/JsonToCommunity.cs
@@ -19,7 +19,7 @@ namespace BSOA.Test.Model.V1
     {
         private static Dictionary<string, Action<JsonReader, Community, Community>> setters = new Dictionary<string, Action<JsonReader, Community, Community>>()
         {
-            ["people"] = (reader, root, me) => JsonToIList<Person>.Read(reader, root, me.People, JsonToPerson.Read)
+            ["people"] = (reader, root, me) => me.People = JsonToIList<Person>.Read(reader, root, null, JsonToPerson.Read)
         };
 
         public static Community Read(JsonReader reader, Community root = null)

--- a/csharp/BSOA/BSOA.Test/Model/V1/Json/JsonToPerson.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Json/JsonToPerson.cs
@@ -32,9 +32,9 @@ namespace BSOA.Test.Model.V1
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, Person item)
+        public static void Write(JsonWriter writer, string propertyName, Person item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
@@ -11,10 +11,10 @@ namespace BSOA.Test.Model.V1
     /// <summary>
     ///  BSOA GENERATED Entity for 'Person'
     /// </summary>
-    public partial class Person : IRow, IEquatable<Person>
+    public partial class Person : IRow<Person>, IEquatable<Person>
     {
-        private PersonTable _table;
-        private int _index;
+        private readonly PersonTable _table;
+        private readonly int _index;
 
         public Person() : this(PersonDatabase.Current.Person)
         { }
@@ -22,32 +22,21 @@ namespace BSOA.Test.Model.V1
         public Person(Community root) : this(root.Database.Person)
         { }
 
-        internal Person(PersonTable table) : this(table, table.Count)
+        public Person(Community root, Person other) : this(root.Database.Person, other)
+        { }
+
+        internal Person(PersonTable table) : this(table, table.Add()._index)
+        { }
+
+        internal Person(PersonTable table, Person other) : this(table ?? PersonDatabase.Current.Person)
         {
-            table.Add();
+            CopyFrom(other);
         }
-        
+
         internal Person(PersonTable table, int index)
         {
             this._table = table;
             this._index = index;
-        }
-
-        public Person(
-            byte age,
-            string name
-        ) 
-            : this(PersonDatabase.Current.Person)
-        {
-            Age = age;
-            Name = name;
-        }
-
-        public Person(Person other) 
-            : this(PersonDatabase.Current.Person)
-        {
-            Age = other.Age;
-            Name = other.Name;
         }
 
         public byte Age
@@ -122,12 +111,13 @@ namespace BSOA.Test.Model.V1
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<Person>.Table => _table;
+        int IRow<Person>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(Person other)
         {
-            _index++;
+            Age = other.Age;
+            Name = other.Name;
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.Model;
 
 namespace BSOA.Test.Model.V1

--- a/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
@@ -22,7 +22,7 @@ namespace BSOA.Test.Model.V1
         public Person(Community root) : this(root.Database.Person)
         { }
 
-        public Person(Community root, Person other) : this(root)
+        public Person(Community root, Person other) : this(root.Database.Person)
         {
             CopyFrom(other);
         }

--- a/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
@@ -22,15 +22,14 @@ namespace BSOA.Test.Model.V1
         public Person(Community root) : this(root.Database.Person)
         { }
 
-        public Person(Community root, Person other) : this(root.Database.Person, other)
-        { }
-
-        internal Person(PersonTable table) : this(table, table.Add()._index)
-        { }
-
-        internal Person(PersonTable table, Person other) : this(table ?? PersonDatabase.Current.Person)
+        public Person(Community root, Person other) : this(root)
         {
             CopyFrom(other);
+        }
+
+        internal Person(PersonTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal Person(PersonTable table, int index)
@@ -38,6 +37,8 @@ namespace BSOA.Test.Model.V1
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         public byte Age
         {

--- a/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
@@ -23,15 +23,14 @@ namespace BSOA.Test.Model.V2
         public Community() : this(new PersonDatabase().Community)
         { }
 
-        public Community(Community other) : this(new PersonDatabase().Community, other)
-        { }
-
-        internal Community(CommunityTable table) : this(table, table.Add()._index)
-        { }
-
-        internal Community(CommunityTable table, Community other) : this(table)
+        public Community(Community other) : this(new PersonDatabase().Community)
         {
             CopyFrom(other);
+        }
+
+        internal Community(CommunityTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal Community(CommunityTable table, int index)
@@ -39,6 +38,8 @@ namespace BSOA.Test.Model.V2
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         public IList<Person> People
         {

--- a/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 using BSOA.IO;
 using BSOA.Model;
@@ -106,7 +105,7 @@ namespace BSOA.Test.Model.V2
         #endregion
 
         #region Easy Serialization
-        public void WriteBsoa(Stream stream)
+        public void WriteBsoa(System.IO.Stream stream)
         {
             using (BinaryTreeWriter writer = new BinaryTreeWriter(stream))
             {
@@ -116,10 +115,10 @@ namespace BSOA.Test.Model.V2
 
         public void WriteBsoa(string filePath)
         {
-            WriteBsoa(File.Create(filePath));
+            WriteBsoa(System.IO.File.Create(filePath));
         }
 
-        public static Community ReadBsoa(Stream stream)
+        public static Community ReadBsoa(System.IO.Stream stream)
         {
             using (BinaryTreeReader reader = new BinaryTreeReader(stream))
             {
@@ -131,15 +130,15 @@ namespace BSOA.Test.Model.V2
 
         public static Community ReadBsoa(string filePath)
         {
-            return ReadBsoa(File.OpenRead(filePath));
+            return ReadBsoa(System.IO.File.OpenRead(filePath));
         }
 
         public static TreeDiagnostics Diagnostics(string filePath)
         {
-            return Diagnostics(File.OpenRead(filePath));
+            return Diagnostics(System.IO.File.OpenRead(filePath));
         }
 
-        public static TreeDiagnostics Diagnostics(Stream stream)
+        public static TreeDiagnostics Diagnostics(System.IO.Stream stream)
         {
             using (BinaryTreeReader btr = new BinaryTreeReader(stream))
             using (TreeDiagnosticsReader reader = new TreeDiagnosticsReader(btr))

--- a/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.IO;
 using BSOA.Model;
 
@@ -43,8 +44,8 @@ namespace BSOA.Test.Model.V2
 
         public IList<Person> People
         {
-            get => _table.Database.Person.List(_table.People[_index]);
-            set => _table.Database.Person.List(_table.People[_index]).SetTo(value);
+            get => TypedList<Person>.Get(_table.Database.Person, _table.People, _index);
+            set => TypedList<Person>.Set(_table.Database.Person, _table.People, _index, value);
         }
 
         #region IEquatable<Community>

--- a/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
@@ -12,10 +12,10 @@ namespace BSOA.Test.Model.V2
     /// <summary>
     ///  BSOA GENERATED Root Entity for 'Community'
     /// </summary>
-    public partial class Community : IRow
+    public partial class Community : IRow<Community>, IEquatable<Community>
     {
-        private CommunityTable _table;
-        private int _index;
+        private readonly CommunityTable _table;
+        private readonly int _index;
 
         internal PersonDatabase Database => _table.Database;
         public ITreeSerializable DB => _table.Database;
@@ -23,9 +23,15 @@ namespace BSOA.Test.Model.V2
         public Community() : this(new PersonDatabase().Community)
         { }
 
-        internal Community(CommunityTable table) : this(table, table.Count)
+        public Community(Community other) : this(new PersonDatabase().Community, other)
+        { }
+
+        internal Community(CommunityTable table) : this(table, table.Add()._index)
+        { }
+
+        internal Community(CommunityTable table, Community other) : this(table)
         {
-            table.Add();
+            CopyFrom(other);
         }
 
         internal Community(CommunityTable table, int index)
@@ -39,7 +45,6 @@ namespace BSOA.Test.Model.V2
             get => _table.Database.Person.List(_table.People[_index]);
             set => _table.Database.Person.List(_table.People[_index]).SetTo(value);
         }
-
 
         #region IEquatable<Community>
         public bool Equals(Community other)
@@ -95,12 +100,12 @@ namespace BSOA.Test.Model.V2
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<Community>.Table => _table;
+        int IRow<Community>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(Community other)
         {
-            _index++;
+            People = other.People;
         }
         #endregion
 

--- a/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
@@ -47,7 +47,7 @@ namespace BSOA.Test.Model.V2
         {
             if (other == null) { return false; }
 
-            if (this.People != other.People) { return false; }
+            if (!object.Equals(this.People, other.People)) { return false; }
 
             return true;
         }

--- a/csharp/BSOA/BSOA.Test/Model/V2/Json/JsonToCommunity.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Json/JsonToCommunity.cs
@@ -19,7 +19,7 @@ namespace BSOA.Test.Model.V2
     {
         private static Dictionary<string, Action<JsonReader, Community, Community>> setters = new Dictionary<string, Action<JsonReader, Community, Community>>()
         {
-            ["people"] = (reader, root, me) => JsonToIList<Person>.Read(reader, root, me.People, JsonToPerson.Read)
+            ["people"] = (reader, root, me) => me.People = JsonToIList<Person>.Read(reader, root, null, JsonToPerson.Read)
         };
 
         public static Community Read(JsonReader reader, Community root = null)

--- a/csharp/BSOA/BSOA.Test/Model/V2/Json/JsonToCommunity.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Json/JsonToCommunity.cs
@@ -39,9 +39,9 @@ namespace BSOA.Test.Model.V2
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, Community item)
+        public static void Write(JsonWriter writer, string propertyName, Community item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Test/Model/V2/Json/JsonToPerson.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Json/JsonToPerson.cs
@@ -32,9 +32,9 @@ namespace BSOA.Test.Model.V2
             return item;
         }
 
-        public static void Write(JsonWriter writer, string propertyName, Person item)
+        public static void Write(JsonWriter writer, string propertyName, Person item, bool required = false)
         {
-            if (item != null)
+            if (required || item != null)
             {
                 writer.WritePropertyName(propertyName);
                 Write(writer, item);

--- a/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.Model;
 
 namespace BSOA.Test.Model.V2

--- a/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
@@ -22,15 +22,14 @@ namespace BSOA.Test.Model.V2
         public Person(Community root) : this(root.Database.Person)
         { }
 
-        public Person(Community root, Person other) : this(root.Database.Person, other)
-        { }
-
-        internal Person(PersonTable table) : this(table, table.Add()._index)
-        { }
-
-        internal Person(PersonTable table, Person other) : this(table ?? PersonDatabase.Current.Person)
+        public Person(Community root, Person other) : this(root)
         {
             CopyFrom(other);
+        }
+
+        internal Person(PersonTable table) : this(table, table.Add()._index)
+        {
+            Init();
         }
 
         internal Person(PersonTable table, int index)
@@ -38,6 +37,8 @@ namespace BSOA.Test.Model.V2
             this._table = table;
             this._index = index;
         }
+
+        partial void Init();
 
         public DateTime Birthdate
         {

--- a/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
@@ -11,10 +11,10 @@ namespace BSOA.Test.Model.V2
     /// <summary>
     ///  BSOA GENERATED Entity for 'Person'
     /// </summary>
-    public partial class Person : IRow, IEquatable<Person>
+    public partial class Person : IRow<Person>, IEquatable<Person>
     {
-        private PersonTable _table;
-        private int _index;
+        private readonly PersonTable _table;
+        private readonly int _index;
 
         public Person() : this(PersonDatabase.Current.Person)
         { }
@@ -22,32 +22,21 @@ namespace BSOA.Test.Model.V2
         public Person(Community root) : this(root.Database.Person)
         { }
 
-        internal Person(PersonTable table) : this(table, table.Count)
+        public Person(Community root, Person other) : this(root.Database.Person, other)
+        { }
+
+        internal Person(PersonTable table) : this(table, table.Add()._index)
+        { }
+
+        internal Person(PersonTable table, Person other) : this(table ?? PersonDatabase.Current.Person)
         {
-            table.Add();
+            CopyFrom(other);
         }
-        
+
         internal Person(PersonTable table, int index)
         {
             this._table = table;
             this._index = index;
-        }
-
-        public Person(
-            DateTime birthdate,
-            string name
-        ) 
-            : this(PersonDatabase.Current.Person)
-        {
-            Birthdate = birthdate;
-            Name = name;
-        }
-
-        public Person(Person other) 
-            : this(PersonDatabase.Current.Person)
-        {
-            Birthdate = other.Birthdate;
-            Name = other.Name;
         }
 
         public DateTime Birthdate
@@ -122,12 +111,13 @@ namespace BSOA.Test.Model.V2
         #endregion
 
         #region IRow
-        ITable IRow.Table => _table;
-        int IRow.Index => _index;
+        ITable IRow<Person>.Table => _table;
+        int IRow<Person>.Index => _index;
 
-        void IRow.Next()
+        public void CopyFrom(Person other)
         {
-            _index++;
+            Birthdate = other.Birthdate;
+            Name = other.Name;
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
@@ -67,8 +67,8 @@ namespace BSOA.Test.Model.V2
         {
             if (other == null) { return false; }
 
-            if (this.Birthdate != other.Birthdate) { return false; }
-            if (this.Name != other.Name) { return false; }
+            if (!object.Equals(this.Birthdate, other.Birthdate)) { return false; }
+            if (!object.Equals(this.Name, other.Name)) { return false; }
 
             return true;
         }

--- a/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
@@ -22,7 +22,7 @@ namespace BSOA.Test.Model.V2
         public Person(Community root) : this(root.Database.Person)
         { }
 
-        public Person(Community root, Person other) : this(root)
+        public Person(Community root, Person other) : this(root.Database.Person)
         {
             CopyFrom(other);
         }

--- a/csharp/BSOA/BSOA.sln
+++ b/csharp/BSOA/BSOA.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BSOA.Generator", "BSOA.Gene
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BSOA.FromJSchema", "BSOA.FromJSchema\BSOA.FromJSchema.csproj", "{047F6B6A-A3C6-45A9-90A3-51986B7F5F1C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BSOA.Demo", "BSOA.Demo\BSOA.Demo.csproj", "{1BBE7333-2B65-445D-ADCE-B10D4AFCC1CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{047F6B6A-A3C6-45A9-90A3-51986B7F5F1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{047F6B6A-A3C6-45A9-90A3-51986B7F5F1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{047F6B6A-A3C6-45A9-90A3-51986B7F5F1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BBE7333-2B65-445D-ADCE-B10D4AFCC1CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BBE7333-2B65-445D-ADCE-B10D4AFCC1CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BBE7333-2B65-445D-ADCE-B10D4AFCC1CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BBE7333-2B65-445D-ADCE-B10D4AFCC1CE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/csharp/BSOA/BSOA/Collections/BitVector.cs
+++ b/csharp/BSOA/BSOA/Collections/BitVector.cs
@@ -42,6 +42,8 @@ namespace BSOA.Collections
             }
             set
             {
+                if (index < 0) { throw new IndexOutOfRangeException(); }
+
                 if (index >= Capacity)
                 {
                     if (DefaultValue) { Count += (index + 1 - Capacity); }

--- a/csharp/BSOA/BSOA/Collections/ColumnDictionary.cs
+++ b/csharp/BSOA/BSOA/Collections/ColumnDictionary.cs
@@ -14,18 +14,38 @@ namespace BSOA.Collections
     {
         private readonly DictionaryColumn<TKey, TValue> _column;
         private readonly int _rowIndex;
+        private NumberList<int> Pairs => _column?._pairs[_rowIndex] ?? NumberList<int>.Empty;
+        private TValue Value(int pairIndex) => _column._values[_column._pairs[_rowIndex][pairIndex]];
 
         public static ColumnDictionary<TKey, TValue> Empty = new ColumnDictionary<TKey, TValue>(null, 0);
 
-        public ColumnDictionary(DictionaryColumn<TKey, TValue> column, int index)
+        private ColumnDictionary(DictionaryColumn<TKey, TValue> column, int index)
         {
-            if (index < 0) { throw new IndexOutOfRangeException(nameof(index)); }
             _column = column;
             _rowIndex = index;
         }
 
-        private NumberList<int> Pairs => _column?._pairs[_rowIndex] ?? NumberList<int>.Empty;
-        private TValue Value(int pairIndex) => _column._values[_column._pairs[_rowIndex][pairIndex]];
+        public static ColumnDictionary<TKey, TValue> Get(DictionaryColumn<TKey, TValue> column, int index)
+        {
+            if (index < 0) { throw new IndexOutOfRangeException(nameof(index)); }
+            return (column?._pairs?[index] == null ? null : new ColumnDictionary<TKey, TValue>(column, index));
+        }
+
+        public static void Set(DictionaryColumn<TKey, TValue> column, int index, IDictionary<TKey, TValue> value)
+        {
+            if (index < 0) { throw new IndexOutOfRangeException(nameof(index)); }
+
+            if (value == null)
+            {
+                column._pairs[index] = null;
+            }
+            else
+            {
+                // Setting List to empty 'coerces' list creation in correct column
+                if (column._pairs[index] == null) { column._pairs[index] = NumberList<int>.Empty; }
+                new ColumnDictionary<TKey, TValue>(column, index).SetTo(value);
+            }
+        }
 
         public bool IsReadOnly => false;
         public int Count => Pairs.Count;

--- a/csharp/BSOA/BSOA/Collections/ColumnDictionary.cs
+++ b/csharp/BSOA/BSOA/Collections/ColumnDictionary.cs
@@ -44,14 +44,14 @@ namespace BSOA.Collections
 
             set
             {
-                int index = InternalIndexOfKey(key);
-                if (index == -1)
+                int pairIndex = InternalIndexOfKey(key);
+                if (pairIndex == -1)
                 {
                     AddInternal(key, value);
                 }
                 else
                 {
-                    _column._values[index] = value;
+                    _column._values[Pairs[pairIndex]] = value;
                 }
             }
         }

--- a/csharp/BSOA/BSOA/Collections/ColumnDictionary.cs
+++ b/csharp/BSOA/BSOA/Collections/ColumnDictionary.cs
@@ -61,6 +61,16 @@ namespace BSOA.Collections
 
         public void SetTo(IDictionary<TKey, TValue> other)
         {
+            if (other is ColumnDictionary<TKey, TValue>)
+            {
+                // Avoid Clear() on SetTo(self)
+                ColumnDictionary<TKey, TValue> otherDictionary = (ColumnDictionary<TKey, TValue>)other;
+                if (object.ReferenceEquals(this._column, otherDictionary._column) && this._rowIndex == otherDictionary._rowIndex)
+                {
+                    return;
+                }
+            }
+
             Clear();
 
             if (other != null)
@@ -257,6 +267,6 @@ namespace BSOA.Collections
             return !left.Equals(right);
         }
 
-        
+
     }
 }

--- a/csharp/BSOA/BSOA/Collections/ColumnDictionary.cs
+++ b/csharp/BSOA/BSOA/Collections/ColumnDictionary.cs
@@ -19,7 +19,7 @@ namespace BSOA.Collections
 
         public static ColumnDictionary<TKey, TValue> Empty = new ColumnDictionary<TKey, TValue>(null, 0);
 
-        private ColumnDictionary(DictionaryColumn<TKey, TValue> column, int index)
+        protected ColumnDictionary(DictionaryColumn<TKey, TValue> column, int index)
         {
             _column = column;
             _rowIndex = index;

--- a/csharp/BSOA/BSOA/Collections/ColumnList.cs
+++ b/csharp/BSOA/BSOA/Collections/ColumnList.cs
@@ -37,7 +37,7 @@ namespace BSOA
         public static ColumnList<T> Get(ListColumn<T> column, int index)
         {
             if (index < 0) { throw new IndexOutOfRangeException(nameof(index)); }
-            return new ColumnList<T>(column, index);
+            return (column._indices[index] == null ? null : new ColumnList<T>(column, index));
         }
 
         public static void Set(ListColumn<T> column, int index, IEnumerable<T> value)
@@ -50,8 +50,6 @@ namespace BSOA
             }
             else
             {
-                // Setting List to empty 'coerces' list creation in correct column
-                if (column._indices[index] == null) { column._indices[index] = NumberList<int>.Empty; }
                 new ColumnList<T>(column, index).SetTo(value);
             }
         }
@@ -87,7 +85,6 @@ namespace BSOA
             }
 
             Clear();
-            Init();
 
             if (other != null)
             {
@@ -111,17 +108,18 @@ namespace BSOA
 
         public void Clear()
         {
+            // Clear values (still need to reclaim space later)
             if (Count > 0)
             {
-                // Clear values (still need to reclaim space later)
                 foreach (int index in Indices)
                 {
                     Values[index] = default(T);
                 }
-
-                // Clear indices
-                Indices.Clear();
             }
+
+            // Clear indices
+            Init();
+            Indices.Clear();
         }
 
         public bool Contains(T item)

--- a/csharp/BSOA/BSOA/Collections/NumberList.cs
+++ b/csharp/BSOA/BSOA/Collections/NumberList.cs
@@ -191,11 +191,21 @@ namespace BSOA.Collections
 
         public static bool operator ==(NumberList<T> left, NumberList<T> right)
         {
+            if (object.ReferenceEquals(left, null))
+            {
+                return object.ReferenceEquals(right, null);
+            }
+
             return left.Equals(right);
         }
 
         public static bool operator !=(NumberList<T> left, NumberList<T> right)
         {
+            if (object.ReferenceEquals(left, null))
+            {
+                return !object.ReferenceEquals(right, null);
+            }
+
             return !(left == right);
         }
     }

--- a/csharp/BSOA/BSOA/Collections/TypedList.cs
+++ b/csharp/BSOA/BSOA/Collections/TypedList.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 
 using BSOA.Extensions;
+using BSOA.Model;
 
 namespace BSOA.Collections
 {
@@ -13,17 +14,55 @@ namespace BSOA.Collections
     ///  TypedList wraps a NumberList and converts it from the internal int (an index of some entity)
     ///  to instances of the entity type for external use.
     /// </summary>
-    public class TypedList<TItem> : IList<TItem>, IReadOnlyList<TItem>
+    public class TypedList<TItem> : IList<TItem>, IReadOnlyList<TItem> where TItem: IRow<TItem>
     {
         private readonly NumberList<int> _inner;
         private readonly Func<int, TItem> _toInstance;
         private readonly Func<TItem, int> _toIndex;
 
-        public TypedList(NumberList<int> indices, Func<int, TItem> toInstance, Func<TItem, int> toIndex)
+        private TypedList(NumberList<int> indices, Func<int, TItem> toInstance, Func<TItem, int> toIndex)
         {
             _inner = indices;
             _toInstance = toInstance;
             _toIndex = toIndex;
+        }
+
+        public static TypedList<TItem> Get(Table<TItem> table, IColumn<NumberList<int>> column, int index)
+        {
+            NumberList<int> indices = column?[index];
+            return (indices == null ? null : new TypedList<TItem>(indices, (i) => table.Get(i), (v) => table.LocalIndex(v)));
+        }
+
+        public static void Set(Table<TItem> table, IColumn<NumberList<int>> column, int index, ICollection<TItem> toValue)
+        {
+            if (toValue == null)
+            {
+                column[index] = null;
+            }
+            else if (toValue.Count == 0)
+            {
+                column[index] = NumberList<int>.Empty;
+            }
+            else
+            {
+                int[] indices = new int[toValue.Count];
+                int i = 0;
+                foreach (TItem value in toValue)
+                {
+                    indices[i++] = table.LocalIndex(value);
+                }
+
+                NumberList<int> current = column[index];
+
+                // Setting to empty coerces list creation in correct column
+                if (current == null)
+                {
+                    column[index] = NumberList<int>.Empty;
+                    current = column[index];
+                }
+
+                current.SetTo(new ArraySlice<int>(indices));
+            }
         }
 
         public TItem this[int index]
@@ -34,7 +73,7 @@ namespace BSOA.Collections
 
         public NumberList<int> Indices => _inner;
 
-        public int Count => _inner.Count;
+        public int Count => _inner?.Count ?? 0;
         public bool IsReadOnly => false;
 
         public void SetTo(IEnumerable<TItem> list)

--- a/csharp/BSOA/BSOA/Collections/TypedList.cs
+++ b/csharp/BSOA/BSOA/Collections/TypedList.cs
@@ -29,7 +29,7 @@ namespace BSOA.Collections
 
         public static TypedList<TItem> Get(Table<TItem> table, IColumn<NumberList<int>> column, int index)
         {
-            NumberList<int> indices = column?[index];
+            NumberList<int> indices = column[index];
             return (indices == null ? null : new TypedList<TItem>(indices, (i) => table.Get(i), (v) => table.LocalIndex(v)));
         }
 
@@ -70,8 +70,6 @@ namespace BSOA.Collections
             get => _toInstance(_inner[index]);
             set => _inner[index] = _toIndex(value);
         }
-
-        public NumberList<int> Indices => _inner;
 
         public int Count => _inner?.Count ?? 0;
         public bool IsReadOnly => false;

--- a/csharp/BSOA/BSOA/Collections/TypedList.cs
+++ b/csharp/BSOA/BSOA/Collections/TypedList.cs
@@ -39,6 +39,12 @@ namespace BSOA.Collections
 
         public void SetTo(IList<TItem> list)
         {
+            if (list is TypedList<TItem>)
+            {
+                // Avoid Clear() on SetTo(self)
+                if (_inner.Equals(((TypedList<TItem>)list)._inner)) { return; }
+            }
+
             _inner.Clear();
 
             if (list != null)

--- a/csharp/BSOA/BSOA/Collections/TypedList.cs
+++ b/csharp/BSOA/BSOA/Collections/TypedList.cs
@@ -20,7 +20,7 @@ namespace BSOA.Collections
         private readonly Func<int, TItem> _toInstance;
         private readonly Func<TItem, int> _toIndex;
 
-        private TypedList(NumberList<int> indices, Func<int, TItem> toInstance, Func<TItem, int> toIndex)
+        protected TypedList(NumberList<int> indices, Func<int, TItem> toInstance, Func<TItem, int> toIndex)
         {
             _inner = indices;
             _toInstance = toInstance;

--- a/csharp/BSOA/BSOA/Collections/TypedList.cs
+++ b/csharp/BSOA/BSOA/Collections/TypedList.cs
@@ -15,9 +15,9 @@ namespace BSOA.Collections
     /// </summary>
     public class TypedList<TItem> : IList<TItem>, IReadOnlyList<TItem>
     {
-        private NumberList<int> _inner;
-        private Func<int, TItem> _toInstance;
-        private Func<TItem, int> _toIndex;
+        private readonly NumberList<int> _inner;
+        private readonly Func<int, TItem> _toInstance;
+        private readonly Func<TItem, int> _toIndex;
 
         public TypedList(NumberList<int> indices, Func<int, TItem> toInstance, Func<TItem, int> toIndex)
         {
@@ -37,7 +37,7 @@ namespace BSOA.Collections
         public int Count => _inner.Count;
         public bool IsReadOnly => false;
 
-        public void SetTo(IList<TItem> list)
+        public void SetTo(IEnumerable<TItem> list)
         {
             if (list is TypedList<TItem>)
             {
@@ -49,9 +49,9 @@ namespace BSOA.Collections
 
             if (list != null)
             {
-                for (int i = 0; i < list.Count; ++i)
+                foreach (TItem item in list)
                 {
-                    _inner.Add(_toIndex(list[i]));
+                    _inner.Add(_toIndex(item));
                 }
             }
         }

--- a/csharp/BSOA/BSOA/Column/ArraySliceColumn.cs
+++ b/csharp/BSOA/BSOA/Column/ArraySliceColumn.cs
@@ -54,6 +54,7 @@ namespace BSOA.Column
 
             set
             {
+                if (index < 0) { throw new IndexOutOfRangeException(); }
                 int chapterIndex = index / ArraySliceChapter<T>.ChapterRowCount;
                 int indexInChapter = index % ArraySliceChapter<T>.ChapterRowCount;
 

--- a/csharp/BSOA/BSOA/Column/DateTimeColumn.cs
+++ b/csharp/BSOA/BSOA/Column/DateTimeColumn.cs
@@ -21,12 +21,12 @@ namespace BSOA.Column
 
         private static DateTime Convert(long value)
         {
-            return new DateTime(value, DateTimeKind.Utc);
+            return (value == 0L ? DateTime.MinValue : new DateTime(value, DateTimeKind.Utc));
         }
 
         private static long Convert(DateTime value)
         {
-            return value.ToUniversalTime().Ticks;
+            return (value == DateTime.MinValue ? 0L : value.ToUniversalTime().Ticks);
         }
     }
 }

--- a/csharp/BSOA/BSOA/Column/DictionaryColumn.cs
+++ b/csharp/BSOA/BSOA/Column/DictionaryColumn.cs
@@ -24,7 +24,7 @@ namespace BSOA.Column
         }
 
         // ColumnFactory untyped constructor
-        public DictionaryColumn(IColumn keys, IColumn values) : this((IColumn<TKey>)keys, (IColumn<TValue>)values)
+        public DictionaryColumn(IColumn keys, IColumn values, object defaultValue) : this((IColumn<TKey>)keys, (IColumn<TValue>)values, (defaultValue == null))
         { }
 
         public override IDictionary<TKey, TValue> this[int index] 

--- a/csharp/BSOA/BSOA/Column/DictionaryColumn.cs
+++ b/csharp/BSOA/BSOA/Column/DictionaryColumn.cs
@@ -14,13 +14,13 @@ namespace BSOA.Column
     {
         internal IColumn<TKey> _keys;
         internal IColumn<TValue> _values;
-        internal NumberListColumn<int> _pairs;
+        internal NullableColumn<NumberList<int>> _pairs;
 
-        public DictionaryColumn(IColumn<TKey> keys, IColumn<TValue> values)
+        public DictionaryColumn(IColumn<TKey> keys, IColumn<TValue> values, bool nullByDefault = true)
         {
             _keys = keys;
             _values = values;
-            _pairs = new NumberListColumn<int>();
+            _pairs = new NullableColumn<NumberList<int>>(new NumberListColumn<int>(), nullByDefault);
         }
 
         // ColumnFactory untyped constructor
@@ -29,8 +29,8 @@ namespace BSOA.Column
 
         public override IDictionary<TKey, TValue> this[int index] 
         {
-            get => new ColumnDictionary<TKey, TValue>(this, index);
-            set => new ColumnDictionary<TKey, TValue>(this, index).SetTo(value);
+            get => ColumnDictionary<TKey, TValue>.Get(this, index);
+            set => ColumnDictionary<TKey, TValue>.Set(this, index, value);
         }
 
         public override int Count => _pairs.Count;
@@ -57,8 +57,8 @@ namespace BSOA.Column
             _pairs.Trim();
 
             // Remove any keys and values which are no longer referenced
-            GarbageCollector.Collect(_pairs, _keys);
-            GarbageCollector.Collect(_pairs, _values);
+            GarbageCollector.Collect((INumberColumn<int>)_pairs.Values, _keys);
+            GarbageCollector.Collect((INumberColumn<int>)_pairs.Values, _values);
 
             _keys.Trim();
             _values.Trim();

--- a/csharp/BSOA/BSOA/Column/ListColumn.cs
+++ b/csharp/BSOA/BSOA/Column/ListColumn.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 
+using BSOA.Collections;
 using BSOA.IO;
 using BSOA.Model;
 
@@ -15,14 +16,14 @@ namespace BSOA.Column
     /// </summary>
     public class ListColumn<T> : LimitedList<IList<T>>, IColumn<IList<T>>
     {
-        internal ArraySliceColumn<int> _indices;
+        internal NullableColumn<NumberList<int>> _indices;
         internal IColumn<T> _values;
 
         public override int Count => _indices.Count;
 
-        public ListColumn(IColumn<T> values)
+        public ListColumn(IColumn<T> values, bool nullByDefault = true)
         {
-            _indices = new ArraySliceColumn<int>();
+            _indices = new NullableColumn<NumberList<int>>(new NumberListColumn<int>(), nullByDefault);
             _values = values;
         }
 
@@ -32,8 +33,8 @@ namespace BSOA.Column
 
         public override IList<T> this[int index]
         {
-            get => new ColumnList<T>(this, index);
-            set => new ColumnList<T>(this, index).SetTo(value);
+            get => ColumnList<T>.Get(this, index);
+            set => ColumnList<T>.Set(this, index, value);
         }
 
         public override void Swap(int index1, int index2)
@@ -58,7 +59,7 @@ namespace BSOA.Column
             _indices.Trim();
 
             // Find any unused values and remove them
-            GarbageCollector.Collect<int, T>(_indices, _values);
+            GarbageCollector.Collect<int, T>((INumberColumn<int>)_indices.Values, _values);
 
             // Trim values afterward to clean up any newly unused space
             _values.Trim();

--- a/csharp/BSOA/BSOA/Column/ListColumn.cs
+++ b/csharp/BSOA/BSOA/Column/ListColumn.cs
@@ -28,7 +28,7 @@ namespace BSOA.Column
         }
 
         // ColumnFactory untyped constructor
-        public ListColumn(IColumn values) : this((IColumn<T>)values)
+        public ListColumn(IColumn values, object defaultValue) : this((IColumn<T>)values, (defaultValue == null))
         { }
 
         public override IList<T> this[int index]

--- a/csharp/BSOA/BSOA/Column/NullableColumn.cs
+++ b/csharp/BSOA/BSOA/Column/NullableColumn.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+using BSOA.IO;
+using BSOA.Model;
+
+namespace BSOA.Column
+{
+    /// <summary>
+    ///  NullableColumn is used to track and return null values when the external
+    ///  type of the column can be null, but the internally stored type doesn't have
+    ///  a separate null representation and so won't round-trip null.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class NullableColumn<T> : LimitedList<T>, IColumn<T> where T : class
+    {
+        protected BooleanColumn IsNull;
+        internal IColumn<T> Values;
+
+        public NullableColumn(IColumn<T> values, bool nullByDefault)
+        {
+            IsNull = new BooleanColumn(nullByDefault);
+            Values = values;
+        }
+
+        public override int Count => Values.Count;
+
+        public override T this[int index]
+        {
+            get
+            {
+                return (IsNull[index] ? null : Values[index]);
+            }
+
+            set
+            {
+                IsNull[index] = (value == null);
+                Values[index] = value;
+            }
+        }
+
+        public override void Clear()
+        {
+            IsNull.Clear();
+            Values.Clear();
+        }
+
+        public override void Swap(int index1, int index2)
+        {
+            IsNull.Swap(index1, index2);
+            Values.Swap(index1, index2);
+        }
+
+        public override void RemoveFromEnd(int count)
+        {
+            IsNull.RemoveFromEnd(count);
+            Values.RemoveFromEnd(count);
+        }
+
+        public void Trim()
+        {
+            Values.Trim();
+        }
+
+        private static Dictionary<string, Setter<NullableColumn<T>>> setters = new Dictionary<string, Setter<NullableColumn<T>>>()
+        {
+            [Names.IsNull] = (r, me) => me.IsNull.Read(r),
+            [Names.Values] = (r, me) => me.Values.Read(r)
+        };
+
+        public void Read(ITreeReader reader)
+        {
+            reader.ReadObject(this, setters);
+
+            if (IsNull.Count == 0 && Values.Count > 0)
+            {
+                // Only wrote values means all values are non-null
+                IsNull[Values.Count - 1] = false;
+                IsNull.SetAll(false);
+            }
+            else if (IsNull.Count > 0 && Values.Count == 0)
+            {
+                // Only wrote nulls means all values are null
+                Values[IsNull.Count - 1] = default(T);
+            }
+        }
+
+        public void Write(ITreeWriter writer)
+        {
+            writer.WriteStartObject();
+
+            if (Count > 0)
+            {
+                int nullValueCount = IsNull.CountTrue;
+
+                if (nullValueCount == Count)
+                {
+                    // If all null, write IsNull only (default is already all null)
+                    writer.Write(Names.IsNull, IsNull);
+                }
+                else if (nullValueCount == 0)
+                {
+                    // If no nulls, write values only (will infer situation on read)
+                    writer.Write(Names.Values, Values);
+                }
+                else
+                {
+                    // If there are some nulls and some values, we must write both
+                    writer.Write(Names.IsNull, IsNull);
+                    writer.Write(Names.Values, Values);
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/csharp/BSOA/BSOA/Column/NullableColumn.cs
+++ b/csharp/BSOA/BSOA/Column/NullableColumn.cs
@@ -55,8 +55,13 @@ namespace BSOA.Column
 
         public override void RemoveFromEnd(int count)
         {
-            IsNull.RemoveFromEnd(count);
             Values.RemoveFromEnd(count);
+
+            int isNullToRemove = IsNull.Count - Values.Count;
+            if (isNullToRemove > 0)
+            {
+                IsNull.RemoveFromEnd(isNullToRemove);
+            }
         }
 
         public void Trim()

--- a/csharp/BSOA/BSOA/Column/NumberColumn.cs
+++ b/csharp/BSOA/BSOA/Column/NumberColumn.cs
@@ -42,6 +42,8 @@ namespace BSOA.Column
 
             set
             {
+                if (index < 0) { throw new IndexOutOfRangeException(); }
+
                 // Track logical count
                 if (index >= Count) { _count = index + 1; }
 

--- a/csharp/BSOA/BSOA/Column/NumberListColumn.cs
+++ b/csharp/BSOA/BSOA/Column/NumberListColumn.cs
@@ -20,7 +20,7 @@ namespace BSOA.Column
         public override NumberList<T> this[int index] 
         {
             get => new NumberList<T>(Inner, index);
-            set => Inner[index] = value.Slice;
+            set => Inner[index] = value?.Slice ?? ArraySlice<T>.Empty;
         }
 
         public void ForEach(Action<ArraySlice<T>> action)

--- a/csharp/BSOA/BSOA/Column/RefListColumn.cs
+++ b/csharp/BSOA/BSOA/Column/RefListColumn.cs
@@ -17,5 +17,8 @@ namespace BSOA.Column
         {
             ReferencedTableName = referencedTableName;
         }
+
+        public RefListColumn(string referencedTableName, object defaultValue) : this(referencedTableName, (defaultValue == null))
+        { }
     }
 }

--- a/csharp/BSOA/BSOA/Column/RefListColumn.cs
+++ b/csharp/BSOA/BSOA/Column/RefListColumn.cs
@@ -1,17 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using BSOA.Collections;
+
 namespace BSOA.Column
 {
     /// <summary>
     ///  RefListColumn provides a reference from an item in one table to a set
     ///  of items in another table. It stores the integer indices of the references.
     /// </summary>
-    public class RefListColumn : NumberListColumn<int>
+    public class RefListColumn : NullableColumn<NumberList<int>>
     {
         public string ReferencedTableName { get; }
 
-        public RefListColumn(string referencedTableName)
+        public RefListColumn(string referencedTableName, bool nullByDefault = true) : base(new NumberListColumn<int>(), nullByDefault)
         {
             ReferencedTableName = referencedTableName;
         }

--- a/csharp/BSOA/BSOA/Column/RefListColumn.cs
+++ b/csharp/BSOA/BSOA/Column/RefListColumn.cs
@@ -17,8 +17,5 @@ namespace BSOA.Column
         {
             ReferencedTableName = referencedTableName;
         }
-
-        public RefListColumn(string referencedTableName, object defaultValue) : this(referencedTableName, (defaultValue == null))
-        { }
     }
 }

--- a/csharp/BSOA/BSOA/Column/StringColumn.cs
+++ b/csharp/BSOA/BSOA/Column/StringColumn.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -13,7 +14,7 @@ namespace BSOA.Column
     /// <summary>
     ///  StringColumn stores strings as UTF-8.
     /// </summary>
-    public class StringColumn : LimitedList<string>, IColumn<string>
+    public class StringColumn : LimitedList<string>, IColumn<string>, INumberColumn<byte>
     {
         private const int SavedValueCountLimit = 128;
         private Dictionary<int, string> _savedValues;
@@ -89,6 +90,13 @@ namespace BSOA.Column
 
                 _savedValues.Clear();
             }
+        }
+
+
+        public void ForEach(Action<ArraySlice<byte>> action)
+        {
+            PushSavedValues();
+            Values.ForEach(action);
         }
 
         public override void Clear()

--- a/csharp/BSOA/BSOA/GarbageCollector.cs
+++ b/csharp/BSOA/BSOA/GarbageCollector.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 
 using BSOA.Collections;
-using BSOA.Column;
 using BSOA.Model;
 
 namespace BSOA

--- a/csharp/BSOA/BSOA/Model/IRow.cs
+++ b/csharp/BSOA/BSOA/Model/IRow.cs
@@ -6,15 +6,13 @@ namespace BSOA.Model
     /// <summary>
     ///  Types which represent Rows from a Table must implement IRow.
     /// </summary>
-    public interface IRow
+    public interface IRow<T>
     {
         // Provide the Table and Index to allow the Table to identify
         // the source of the row and copy it from other Table instances.
         ITable Table { get; }
         int Index { get; }
 
-        // Reset this instance to refer to the next item in the table.
-        // This provides a way to set up many instances without allocation for each.
-        void Next();
+        void CopyFrom(T other);
     }
 }

--- a/csharp/BSOA/BSOA/Model/ITable.cs
+++ b/csharp/BSOA/BSOA/Model/ITable.cs
@@ -3,7 +3,7 @@
 
 namespace BSOA.Model
 {
-    public interface ITable<T> : IColumn<T>, ITable where T : IRow
+    public interface ITable<T> : IColumn<T>, ITable where T : IRow<T>
     { }
 
     public interface ITable : IColumn

--- a/csharp/BSOA/BSOA/Model/Table.cs
+++ b/csharp/BSOA/BSOA/Model/Table.cs
@@ -42,6 +42,7 @@ namespace BSOA.Model
 
             set
             {
+                if (index < 0) { throw new IndexOutOfRangeException(); }
                 if (index >= Count) { _count = index + 1; }
                 Get(index).CopyFrom(value);
             }

--- a/csharp/BSOA/BSOA/Model/Table.cs
+++ b/csharp/BSOA/BSOA/Model/Table.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
-using BSOA.Collections;
 using BSOA.IO;
 
 namespace BSOA.Model
@@ -73,10 +72,7 @@ namespace BSOA.Model
             }
         }
 
-        public TypedList<T> List(NumberList<int> indices)
-        {
-            return new TypedList<T>(indices, (index) => this.Get(index), (value) => this.LocalIndex(value));
-        }
+
 
         /// <summary>
         ///  Add a new item to the end of this table.

--- a/csharp/BSOA/BSOA/Model/Table.cs
+++ b/csharp/BSOA/BSOA/Model/Table.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 using BSOA.Collections;
 using BSOA.IO;
@@ -18,19 +19,19 @@ namespace BSOA.Model
     ///  See BSOA.Demo
     /// </remarks>
     /// <typeparam name="T">SoA Item type this is a Table of</typeparam>
-    public abstract class Table<T> : LimitedList<T>, ITable<T> where T : IRow
+    public abstract class Table<T> : LimitedList<T>, ITable<T> where T : IRow<T>
     {
         private int _count;
         protected Dictionary<string, IColumn> Columns { get; private set; }
 
-        public Table()
+        protected Table()
         {
             Columns = new Dictionary<string, IColumn>();
         }
 
-        public override int Count => _count;
-
         public abstract T Get(int index);
+
+        public override int Count => _count;
 
         public override T this[int index]
         {
@@ -43,18 +44,7 @@ namespace BSOA.Model
             set
             {
                 if (index >= Count) { _count = index + 1; }
-
-                IRow row = (IRow)value;
-                if (object.ReferenceEquals(this, row.Table) && row.Index == index)
-                {
-                    // Already here
-                    return;
-                }
-                else
-                {
-                    // Copy from other table
-                    CopyItem(index, row.Table, row.Index);
-                }
+                Get(index).CopyFrom(value);
             }
         }
 
@@ -68,17 +58,18 @@ namespace BSOA.Model
         {
             if (value == null) { return -1; }
 
-            IRow row = (IRow)value;
-            if (object.ReferenceEquals(this, row.Table))
+            if (object.ReferenceEquals(value.Table, this))
             {
                 // Already here
-                return row.Index;
+                return value.Index;
             }
             else
             {
                 // Copy from other table
-                CopyItem(_count, row.Table, row.Index);
-                return _count++;
+                T result = Add();
+                result.CopyFrom(value);
+
+                return result.Index;
             }
         }
 
@@ -93,20 +84,15 @@ namespace BSOA.Model
         /// <returns>New SoA item instance</returns>
         public override T Add()
         {
-            _count++;
-            return this[Count - 1];
+            int newIndex = Interlocked.Increment(ref _count) - 1;
+            return Get(newIndex);
         }
 
         public override void Add(T item)
         {
-            IRow row = (IRow)item;
-            if (object.ReferenceEquals(this, row.Table))
+            if (!object.ReferenceEquals(item.Table, this) || item.Index != Count - 1)
             {
-                return;
-            }
-            else
-            {
-                this[Count] = item;
+                Add().CopyFrom(item);
             }
         }
 
@@ -126,17 +112,6 @@ namespace BSOA.Model
         {
             Columns[name] = column;
             return column;
-        }
-
-        public override void CopyItem(int toIndex, ILimitedList fromList, int fromIndex)
-        {
-            Table<T> other = fromList as Table<T>;
-            if (other == null) { throw new ArgumentException(nameof(fromList)); }
-
-            foreach (var pair in Columns)
-            {
-                pair.Value.CopyItem(toIndex, other.Columns[pair.Key], fromIndex);
-            }
         }
 
         public override void Swap(int index1, int index2)

--- a/csharp/BSOA/Directory.Build.props
+++ b/csharp/BSOA/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Version for all BSOA binaries and packages -->
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <!-- Ensure all outputs and intermediates go to bld\, providing easy cleanup and signing for pipeline builds -->


### PR DESCRIPTION
- Add support for null lists and modify templates to handle.
- Add support for DateTime.MinValue as default.
- Add 'required' arg for JsonTo classes to allow always emitting desired properties.
- Generator post-replacements redesign; can specify literal text and restrict applicable files.
- Fix Dictionary bug in changing existing key's value.
- Fix Equals for list types exposed as interface type.
- Fix Copy constructors to properly deep clone referenced objects recursively.
- Fix TypedList, ColumnList.SetTo(self).
- Fix NumberList ==, != null handling.
- Consolidate Table Add code on Add(); ensure assigning new index is thread-safe.
- Add Entity Init() partial method for custom constructor initialization logic.
- CollectionReadVerifier null handling; Equals verification added.
- Check Column set out of range; fix found issues.
- Fix NullableColumn out-of-range on RemoveFromEnd when BitVector has trailing defaults.
- Re-adding demo (FileSystem index)
