### PR TITLE
BSOA 0.5.2

### DIFF
--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/File.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.Model;
@@ -24,6 +25,11 @@ namespace BSOA.Demo.Model.BSOA
         { }
 
         public File(FileSystem root, File other) : this(root.Database.File)
+        {
+            CopyFrom(other);
+        }
+
+        internal File(FileSystemDatabase database, File other) : this(database.File)
         {
             CopyFrom(other);
         }
@@ -172,6 +178,11 @@ namespace BSOA.Demo.Model.BSOA
             CreatedUtc = other.CreatedUtc;
             Attributes = other.Attributes;
             Length = other.Length;
+        }
+
+        internal static File Copy(FileSystemDatabase database, File other)
+        {
+            return (other == null ? null : new File(database, other));
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/FileSystem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.IO;
@@ -119,8 +120,8 @@ namespace BSOA.Demo.Model.BSOA
 
         public void CopyFrom(FileSystem other)
         {
-            Folders = other.Folders;
-            Files = other.Files;
+            Folders = other.Folders?.Select((item) => Folder.Copy(_table.Database, item)).ToList();
+            Files = other.Files?.Select((item) => File.Copy(_table.Database, item)).ToList();
         }
         #endregion
 

--- a/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
+++ b/csharp/BSOA/BSOA.Demo/Model/BSOA/Folder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.Model;
@@ -24,6 +25,11 @@ namespace BSOA.Demo.Model.BSOA
         { }
 
         public Folder(FileSystem root, Folder other) : this(root.Database.Folder)
+        {
+            CopyFrom(other);
+        }
+
+        internal Folder(FileSystemDatabase database, Folder other) : this(database.Folder)
         {
             CopyFrom(other);
         }
@@ -120,6 +126,11 @@ namespace BSOA.Demo.Model.BSOA
         {
             ParentIndex = other.ParentIndex;
             Name = other.Name;
+        }
+
+        internal static Folder Copy(FileSystemDatabase database, Folder other)
+        {
+            return (other == null ? null : new Folder(database, other));
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Generator/Templates/Company.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Company.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.IO;
@@ -167,8 +168,12 @@ namespace BSOA.Generator.Templates
             Id = other.Id;
             //  </OtherAssignment>
             JoinPolicy = other.JoinPolicy;
-            Owner = other.Owner;
-            Members = other.Members;
+            //  <RefOtherAssignment>
+            Owner = Employee.Copy(_table.Database, other.Owner);
+            //  </RefOtherAssignment>
+            //  <RefListOtherAssignment>
+            Members = other.Members?.Select((item) => Employee.Copy(_table.Database, item)).ToList();
+            //  </RefListOtherAssignment>
             // </OtherAssignmentList>
         }
         #endregion

--- a/csharp/BSOA/BSOA.Generator/Templates/Team.cs
+++ b/csharp/BSOA/BSOA.Generator/Templates/Team.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.Model;
@@ -24,6 +25,11 @@ namespace BSOA.Generator.Templates
         { }
 
         public Team(Company root, Team other) : this(root.Database.Team)
+        {
+            CopyFrom(other);
+        }
+
+        internal Team(CompanyDatabase database, Team other) : this(database.Team)
         {
             CopyFrom(other);
         }
@@ -166,9 +172,18 @@ namespace BSOA.Generator.Templates
             Id = other.Id;
             //  </OtherAssignment>
             JoinPolicy = other.JoinPolicy;
-            Owner = other.Owner;
-            Members = other.Members;
+            //  <RefOtherAssignment>
+            Owner = Employee.Copy(_table.Database, other.Owner);
+            //  </RefOtherAssignment>
+            //  <RefListOtherAssignment>
+            Members = other.Members?.Select((item) => Employee.Copy(_table.Database, item)).ToList();
+            //  </RefListOtherAssignment>
             // </OtherAssignmentList>
+        }
+
+        internal static Team Copy(CompanyDatabase database, Team other)
+        {
+            return (other == null ? null : new Team(database, other));
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToString.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToString.cs
@@ -14,12 +14,13 @@ namespace BSOA.Json.Converters
 
         public static string Read(JsonReader reader)
         {
-            return (string)reader.Value;
+            // Handle null, strings, and DateTime -> string
+            return reader.Value?.ToString();
         }
 
         public static void Write(JsonWriter writer, string propertyName, string item, string defaultValue = default, bool required = false)
         {
-            if (required || item != defaultValue)
+            if (required || (item != defaultValue && item != null))
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);

--- a/csharp/BSOA/BSOA.Json/Converters/JsonToString.cs
+++ b/csharp/BSOA/BSOA.Json/Converters/JsonToString.cs
@@ -20,7 +20,7 @@ namespace BSOA.Json.Converters
 
         public static void Write(JsonWriter writer, string propertyName, string item, string defaultValue = default, bool required = false)
         {
-            if (required || (item != defaultValue && item != null))
+            if (required || item != defaultValue)
             {
                 writer.WritePropertyName(propertyName);
                 writer.WriteValue(item);

--- a/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Community.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.IO;
@@ -107,7 +108,7 @@ namespace BSOA.Test.Model.V1
 
         public void CopyFrom(Community other)
         {
-            People = other.People;
+            People = other.People?.Select((item) => Person.Copy(_table.Database, item)).ToList();
         }
         #endregion
 

--- a/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V1/Person.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.Model;
@@ -24,6 +25,11 @@ namespace BSOA.Test.Model.V1
         { }
 
         public Person(Community root, Person other) : this(root.Database.Person)
+        {
+            CopyFrom(other);
+        }
+
+        internal Person(PersonDatabase database, Person other) : this(database.Person)
         {
             CopyFrom(other);
         }
@@ -120,6 +126,11 @@ namespace BSOA.Test.Model.V1
         {
             Age = other.Age;
             Name = other.Name;
+        }
+
+        internal static Person Copy(PersonDatabase database, Person other)
+        {
+            return (other == null ? null : new Person(database, other));
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Community.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.IO;
@@ -107,7 +108,7 @@ namespace BSOA.Test.Model.V2
 
         public void CopyFrom(Community other)
         {
-            People = other.People;
+            People = other.People?.Select((item) => Person.Copy(_table.Database, item)).ToList();
         }
         #endregion
 

--- a/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
+++ b/csharp/BSOA/BSOA.Test/Model/V2/Person.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using BSOA.Collections;
 using BSOA.Model;
@@ -24,6 +25,11 @@ namespace BSOA.Test.Model.V2
         { }
 
         public Person(Community root, Person other) : this(root.Database.Person)
+        {
+            CopyFrom(other);
+        }
+
+        internal Person(PersonDatabase database, Person other) : this(database.Person)
         {
             CopyFrom(other);
         }
@@ -120,6 +126,11 @@ namespace BSOA.Test.Model.V2
         {
             Birthdate = other.Birthdate;
             Name = other.Name;
+        }
+
+        internal static Person Copy(PersonDatabase database, Person other)
+        {
+            return (other == null ? null : new Person(database, other));
         }
         #endregion
     }

--- a/csharp/BSOA/BSOA/Names.cs
+++ b/csharp/BSOA/BSOA/Names.cs
@@ -38,4 +38,38 @@ namespace BSOA
         public const string Keys = "k";
         public const string Pairs = "p";
     }
+
+    //// Verbose form
+    //public static class Names
+    //{
+    //    // IColumn standard and wrapped columns
+    //    public const string Count = "Count";
+    //    public const string Values = "Values";
+
+    //    // Columns containing direct arrays
+    //    public const string Array = "Array";
+
+    //    // Columns containing int indices to other rows
+    //    public const string Indices = "Indices";
+
+    //    // Table
+    //    public const string Columns = "Columns";
+
+    //    // NullableColumn
+    //    public const string IsNull = "IsNull";
+
+    //    // BitVector
+    //    public const string Capacity = "Capacity";
+
+    //    // NumberListColumn
+    //    public const string Chapters = "Chapters";
+    //    public const string PageStart = "PageStart";
+    //    public const string ValueEnd = "ValueEnd";
+    //    public const string SmallValues = "SmallValues";
+    //    public const string LargeValues = "LargeValues";
+
+    //    // DictionaryColumn
+    //    public const string Keys = "Keys";
+    //    public const string Pairs = "Pairs";
+    //}
 }

--- a/csharp/BSOA/Directory.Build.props
+++ b/csharp/BSOA/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Version for all BSOA binaries and packages -->
-    <Version>0.5.1</Version>
+    <Version>0.5.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <!-- Ensure all outputs and intermediates go to bld\, providing easy cleanup and signing for pipeline builds -->


### PR DESCRIPTION
- Fix Copy constructors to do correct deep copy even in same database.
- JsonToString.Read: Handle values Newtonsoft interprets as DateTimes.
- JsonReader.ReadObject: Support non-strict option, add location to exception message.
- Names: Include full name strings for easy debuggability.